### PR TITLE
Fix feeds to use new(ish)-style feeds framework.

### DIFF
--- a/pybb/feeds.py
+++ b/pybb/feeds.py
@@ -1,4 +1,4 @@
-from django.contrib.syndication.feeds import Feed
+from django.contrib.syndication.views import Feed
 from django.utils.feedgenerator import Atom1Feed
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _

--- a/pybb/templates/pybb/base.html
+++ b/pybb/templates/pybb/base.html
@@ -6,8 +6,8 @@
 {%block head %}
     {% block pybb_styles_extra %}{% endblock %}
     <!-- Feeds -->
-    <link rel="alternate" type="application/atom+xml" href="{% url pybb:feed "posts" %}" title="{% trans "Latest posts on forum" %}" >
-    <link rel="alternate" type="application/atom+xml" href="{% url pybb:feed "topics" %}" title="{% trans "Latest topics on forum" %}" >
+    <link rel="alternate" type="application/atom+xml" href="{% url pybb:feed_posts %}" title="{% trans "Latest posts on forum" %}" >
+    <link rel="alternate" type="application/atom+xml" href="{% url pybb:feed_topics %}" title="{% trans "Latest topics on forum" %}" >
     {% block pybb_scripts_extra %}{% endblock %}
     {% block pybb_head_extra %}{% endblock %}
     {% if PYBB_ENABLE_SELF_CSS %}

--- a/pybb/tests.py
+++ b/pybb/tests.py
@@ -227,11 +227,11 @@ class FeaturesTest(TestCase, SharedTestModule):
         self.assertEqual(client.get(topic_in_hidden.get_absolute_url()).status_code, 404)
 
         self.assertNotContains(client.get(reverse('pybb:index')), forum_hidden.get_absolute_url())
-        self.assertNotContains(client.get(reverse('pybb:feed', kwargs={'url': 'topics'})), topic_hidden.get_absolute_url())
-        self.assertNotContains(client.get(reverse('pybb:feed', kwargs={'url': 'topics'})), topic_in_hidden.get_absolute_url())
+        self.assertNotContains(client.get(reverse('pybb:feed_topics')), topic_hidden.get_absolute_url())
+        self.assertNotContains(client.get(reverse('pybb:feed_topics')), topic_in_hidden.get_absolute_url())
 
-        self.assertNotContains(client.get(reverse('pybb:feed', kwargs={'url': 'posts'})), post_hidden.get_absolute_url())
-        self.assertNotContains(client.get(reverse('pybb:feed', kwargs={'url': 'posts'})), post_in_hidden.get_absolute_url())
+        self.assertNotContains(client.get(reverse('pybb:feed_posts')), post_hidden.get_absolute_url())
+        self.assertNotContains(client.get(reverse('pybb:feed_posts')), post_in_hidden.get_absolute_url())
         self.assertEqual(client.get(forum_hidden.get_absolute_url()).status_code, 404)
         self.assertEqual(client.get(topic_hidden.get_absolute_url()).status_code, 404)
 

--- a/pybb/urls.py
+++ b/pybb/urls.py
@@ -6,15 +6,10 @@ from views import IndexView, CategoryView, ForumView, TopicView, AddPostView, Ed
     CloseTopicView, OpenTopicView, ModeratePost
 
 
-feeds = {
-    'posts': LastPosts,
-    'topics': LastTopics
-}
-
 urlpatterns = patterns('',
                        # Syndication feeds
-                       url('^feeds/(?P<url>.*)/$', 'django.contrib.syndication.views.feed',
-                           {'feed_dict': feeds}, name='feed'),
+                       url('^feeds/posts/$', LastPosts(), name='feed_posts'),
+                       url('^feeds/topics/$', LastTopics(), name='feed_topics'),
                        )
 
 urlpatterns += patterns('pybb.views',


### PR DESCRIPTION
Old-style feeds were deprecated in Django 1.2 and have been removed in Django 1.4.
