### PR TITLE
Don't alter functions behaviour based on `user.is_staff` flag.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -182,8 +182,6 @@ Each function in list should accept `auth.User` instance as first argument and `
 for example this is enabled by default `rstrip_str` cleaner::
 
     def rstrip_str(user, str):
-        if user.is_staff:
-            return str
         return '\n'.join([s.rstrip() for s in str.splitlines()])
 
 default is::

--- a/pybb/util.py
+++ b/pybb/util.py
@@ -5,22 +5,20 @@ def unescape(text):
     """
     Do reverse escaping.
     """
-    return text.replace('&amp;', '&').replace('&lt;', '<').replace('&gt;', '>').replace('&quot;', '"').replace('&#39;', '\'')
+    return text.replace('&amp;', '&').replace('&lt;', '<').replace('&gt;',
+        '>').replace('&quot;', '"').replace('&#39;', '\'')
 
 
 def filter_blanks(user, str):
     """
     Replace more than 3 blank lines with only 1 blank line
     """
-    if user.is_staff:
-        return str
     return re.sub(r'\n{2}\n+', '\n', str)
+
 
 def rstrip_str(user, str):
     """
     Replace strings with spaces (tabs, etc..) only with newlines
     Remove blank line at the end
     """
-    if user.is_staff:
-        return str
     return '\n'.join([s.rstrip() for s in str.splitlines()])


### PR DESCRIPTION
Relying on arbitrary user flags in string manipulation functions can lead to unexpected side effects.

If necessary, the old behaviour can be achieved by specifying custom `PYBB_BODY_CLEANERS`.
