### PR TITLE
Fixing a bug of clearing poll questions after the second post in a topic maked by an author

### DIFF
--- a/pybb/views.py
+++ b/pybb/views.py
@@ -214,11 +214,11 @@ class PostEditMixin(object):
                         pollformset.save()
                     else:
                         success = False
-                else:
-                    self.object.topic.poll_question = None
-                    self.object.topic.save()
-                    self.object.topic.poll_answers.all().delete()
-                    pollformset = PollAnswerFormSet()
+                #else:
+                #    self.object.topic.poll_question = None
+                #    self.object.topic.save()
+                #    self.object.topic.poll_answers.all().delete()
+                #    pollformset = PollAnswerFormSet()
 
                 if success:
                     transaction.commit()


### PR DESCRIPTION
Fixing a bug of clearing poll questions after the second post in a topic maked by an author. For example: http://www.pybbm.org/topic/2032/
