### PR TITLE
Updated MANIFEST.in to include translations

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include pybb/static *
 recursive-include pybb/templates *
+recursive-include pybb/locale *
 include README.rst


### PR DESCRIPTION
Without this, the "pip install ..." routine does not install contents of the pybb/locale/*. At least for me. Up for review.
