### PR TITLE
migrate url tags to Django 1.5

### DIFF
--- a/pybb/templates/pybb/_button_new_topic.html
+++ b/pybb/templates/pybb/_button_new_topic.html
@@ -1,1 +1,2 @@
-{% load i18n %}<a href="{% url pybb:add_topic forum.id %}" class="new-topic btn btn-primary">{% trans "New topic" %}</a>
+{% load url from future %}
+{% load i18n %}<a href="{% url 'pybb:add_topic' forum.id %}" class="new-topic btn btn-primary">{% trans "New topic" %}</a>

--- a/pybb/templates/pybb/_markitup.html
+++ b/pybb/templates/pybb/_markitup.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 <script type="text/javascript" src="{{ STATIC_URL }}markitup/ajax_csrf.js"></script>
 <script type="text/javascript" src="{{ STATIC_URL }}markitup/jquery.markitup.js"></script>
 <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}markitup/skins/simple/style.css">
@@ -6,7 +7,7 @@
 
 <script type="text/javascript">
 $(function() {
-    mySettings['previewParserPath'] = '{% url pybb:post_ajax_preview %}';
+    mySettings['previewParserPath'] = '{% url 'pybb:post_ajax_preview' %}';
     mySettings['previewPosition'] = 'before';
     mySettings['resizeHandle'] = true;
     mySettings['markupSet'] = [

--- a/pybb/templates/pybb/_need_to_login_message.html
+++ b/pybb/templates/pybb/_need_to_login_message.html
@@ -1,2 +1,3 @@
+{% load url from future %}
 {% load i18n %}
-<a href="{% url registration_register %}">{% trans "Register" %}</a> {% trans "or" %} <a href="{% url auth_login %}">{% trans "login" %}</a> {% trans "to create to post a reply" %}.
+<a href="{% url 'registration_register' %}">{% trans "Register" %}</a> {% trans "or" %} <a href="{% url 'auth_login' %}">{% trans "login" %}</a> {% trans "to create to post a reply" %}.

--- a/pybb/templates/pybb/base.html
+++ b/pybb/templates/pybb/base.html
@@ -1,4 +1,7 @@
 {% extends PYBB_TEMPLATE|default:"base.html" %}
+
+{% load url from future %}
+
 {% load i18n pybb_tags %}
 
 {%block title %}{{ PYBB_DEFAULT_TITLE }}{% endblock title %}
@@ -6,8 +9,8 @@
 {% block extra_head %}
     {{ block.super }}
     <!-- Feeds -->
-    <link rel="alternate" type="application/atom+xml" href="{% url pybb:feed_posts %}" title="{% trans "Latest posts on forum" %}" >
-    <link rel="alternate" type="application/atom+xml" href="{% url pybb:feed_topics %}" title="{% trans "Latest topics on forum" %}" >
+    <link rel="alternate" type="application/atom+xml" href="{% url 'pybb:feed_posts' %}" title="{% trans "Latest posts on forum" %}" >
+    <link rel="alternate" type="application/atom+xml" href="{% url 'pybb:feed_topics' %}" title="{% trans "Latest topics on forum" %}" >
 {% endblock %}
 
 {% block breadcrumb %}

--- a/pybb/templates/pybb/breadcrumb.html
+++ b/pybb/templates/pybb/breadcrumb.html
@@ -1,7 +1,8 @@
+{% load url from future %}
 {% load i18n pybb_tags %}
 <ul class='breadcrumb'>
     {% include "pybb/breadcrumb_top_extra_crumb.html" %}
-    <li><a href="{% url pybb:index %}">{% trans "Home" %}</a> <span class="divider">/</span></li>
+    <li><a href="{% url 'pybb:index' %}">{% trans "Home" %}</a> <span class="divider">/</span></li>
     {% if object %}
         {% if object.get_parents %}
             {% for obj in object.get_parents %}

--- a/pybb/templates/pybb/category.html
+++ b/pybb/templates/pybb/category.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 {% load i18n pybb_tags %}
 
 <div class='category'>
@@ -41,7 +42,7 @@
             </tr>
         {% empty %}
             <h3>{% trans "No forums created" %}</h3>
-            <a href="{% url admin:pybb_forum_add %}">{% trans "Add forum now" %}</a>
+            <a href="{% url 'admin:pybb_forum_add' %}">{% trans "Add forum now" %}</a>
         {% endfor %}
         </tbody>
     </table>

--- a/pybb/templates/pybb/edit_profile.html
+++ b/pybb/templates/pybb/edit_profile.html
@@ -1,4 +1,7 @@
 {% extends 'pybb/base.html' %}
+
+{% load url from future %}
+
 {% load i18n thumbnail pybb_tags %}
 
 {% block title %}{% trans "Profile editing" %}{% endblock title %}
@@ -12,7 +15,7 @@
         <img src="{{ PYBB_DEFAULT_AVATAR_URL }}" alt="avatar">
     {% endthumbnail %}
     </div>
-    <p><a href="{% url auth_password_change %}">{% trans "Change the password" %}</a></p>
+    <p><a href="{% url 'auth_password_change' %}">{% trans "Change the password" %}</a></p>
     <form method="post" enctype="multipart/form-data" class="profile-edit">
         {% csrf_token %}
         <fieldset>
@@ -28,7 +31,7 @@
                 {% pybb_link sub %}
                 &mdash;
                 <strong>
-                    <a href="{% url pybb:delete_subscription sub.id %}">{% trans "delete" %}</a>
+                    <a href="{% url 'pybb:delete_subscription' sub.id %}">{% trans "delete" %}</a>
                 </strong>
             </li>
         {% endfor %}

--- a/pybb/templates/pybb/index.html
+++ b/pybb/templates/pybb/index.html
@@ -1,4 +1,7 @@
 {% extends 'pybb/base.html' %}
+
+{% load url from future %}
+
 {% load i18n %}
 
 {% block title %}{{ PYBB_DEFAULT_TITLE }}{% endblock title %}
@@ -14,14 +17,14 @@
         {% endfor %}
     {% else %}
         <h2>{% trans "Forum categories are not created" %}</h2>
-        <a href="{% url admin:pybb_category_add %}">{% trans "Add a category now" %}</a>
+        <a href="{% url 'admin:pybb_category_add' %}">{% trans "Add a category now" %}</a>
     {% endif %}
     {% if user.is_authenticated %}
         <div id='mark-all-as-read'>
-            <a href='{% url pybb:topic_latest %}'>
+            <a href='{% url 'pybb:topic_latest' %}'>
                 {% trans "Last updates in topics" %}
             </a>
-            <a href='{% url pybb:mark_all_as_read %}'>
+            <a href='{% url 'pybb:mark_all_as_read' %}'>
                 {% trans "Mark all forums as read" %}
             </a>
         </div>

--- a/pybb/templates/pybb/latest_topics.html
+++ b/pybb/templates/pybb/latest_topics.html
@@ -1,4 +1,7 @@
 {% extends 'pybb/base.html' %}
+
+{% load url from future %}
+
 {% load pybb_tags i18n %}
 
 {% block title %}{% trans "Last updates in topics" %}{% endblock title %}
@@ -26,7 +29,7 @@
 
         {% if user.is_authenticated %}
             <div id='mark-all-as-read'>
-                <a href='{% url pybb:mark_all_as_read %}'>
+                <a href='{% url 'pybb:mark_all_as_read' %}'>
                     {% trans "Mark all topics as read" %}
                 </a>
             </div>

--- a/pybb/templates/pybb/poll.html
+++ b/pybb/templates/pybb/poll.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 {% load i18n pybb_tags %}
 
 <div class="poll">
@@ -16,7 +17,7 @@
       {% if topic|pybb_topic_poll_not_voted:request.user %}
         <tr class="poll-answer-choice">
           <td>
-            <form class="poll-form" action="{% url pybb:topic_poll_vote topic.pk %}" method="post">
+            <form class="poll-form" action="{% url 'pybb:topic_poll_vote' topic.pk %}" method="post">
               {% csrf_token %}
               {% include "pybb/form.html" with form=poll_form %}
               <p class="submit">{% include "pybb/_button_submit.html" %}</p>

--- a/pybb/templates/pybb/post_form.html
+++ b/pybb/templates/pybb/post_form.html
@@ -1,12 +1,13 @@
+{% load url from future %}
 {% load i18n pybb_tags %}
 <form class="post-form" action="
     {% if forum %}
-        {% url pybb:add_topic forum.pk %}
+        {% url 'pybb:add_topic' forum.pk %}
     {% else %}
         {% if topic %}
-            {% url pybb:add_post topic.pk %}
+            {% url 'pybb:add_post' topic.pk %}
         {% else %}
-            {% url pybb:edit_post pk=object.pk %}
+            {% url 'pybb:edit_post' pk=object.pk %}
         {% endif %}
     {% endif %}" method="post" enctype="multipart/form-data">
   {% csrf_token %}

--- a/pybb/templates/pybb/post_template.html
+++ b/pybb/templates/pybb/post_template.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 {% load i18n pybb_tags thumbnail %}
 
 <a name="post-{{ post.id }}"></a> {# may be remove this string? #}
@@ -32,19 +33,19 @@
 
             <div class="post-controls">
                 {% if user.is_moderator or post|pybb_posted_by:user %}
-                    <a href="{% url pybb:edit_post pk=post.id %}">{% trans "Edit" %}</a>
+                    <a href="{% url 'pybb:edit_post' pk=post.id %}">{% trans "Edit" %}</a>
                 {% endif %}
                 {% if user.is_moderator %}
-                    <a onclick="pybb_delete_post('{% url pybb:delete_post post.id %}',
+                    <a onclick="pybb_delete_post('{% url 'pybb:delete_post' post.id %}',
                             'post-{{ post.id }}', '{% trans 'Delete post?' %}'); return false;"
-                       href="{% url pybb:delete_post post.id %}">{% trans "Delete" %}</a>
+                       href="{% url 'pybb:delete_post' post.id %}">{% trans "Delete" %}</a>
                     {% if post.on_moderation %}
-                    <a href="{% url pybb:moderate_post pk=post.id %}">{% trans "Approve post" %}</a>
+                    <a href="{% url 'pybb:moderate_post' pk=post.id %}">{% trans "Approve post" %}</a>
                     {% endif %}
                 {% endif %}
 
                 {% if perms.pybb.change_post and user.is_staff %}
-                    <a href="{% url admin:pybb_post_change post.id %}">{% trans 'Admin' %}</a>
+                    <a href="{% url 'admin:pybb_post_change' post.id %}">{% trans 'Admin' %}</a>
                 {% endif %}
 
             </div>
@@ -71,7 +72,7 @@
                     {% endif %}
             {% endcomment %}
             <div class="post-related">
-                <a href="{% url pybb:add_post topic.id %}?quote_id={{ post.id }}">{% trans "quote" %}</a>
+                <a href="{% url 'pybb:add_post' topic.id %}?quote_id={{ post.id }}">{% trans "quote" %}</a>
                 <div class='attachments'>
                     {% for attachment in post.attachments.all %}
                         <a href="{{ attachment.file.url }}"><img src="{{ STATIC_URL }}pybb/img/attachment.png"> {{ attachment.size_display }}</a>

--- a/pybb/templates/pybb/topic.html
+++ b/pybb/templates/pybb/topic.html
@@ -1,4 +1,7 @@
 {% extends 'pybb/base.html' %}
+
+{% load url from future %}
+
 {% load pybb_tags i18n %}
 
 {% block title %}{{ topic }}{% endblock %}
@@ -46,28 +49,28 @@
             <div class="controls">
                 {% if user.is_moderator %}
                     {% if topic.sticky %}
-                        <a href="{% url pybb:unstick_topic topic.id %}">{% trans "Unstick topic" %}</a> /
+                        <a href="{% url 'pybb:unstick_topic' topic.id %}">{% trans "Unstick topic" %}</a> /
                     {% else %}
-                        <a href="{% url pybb:stick_topic topic.id %}">{% trans "Stick topic" %}</a> /
+                        <a href="{% url 'pybb:stick_topic' topic.id %}">{% trans "Stick topic" %}</a> /
                     {% endif %}
 
                     {% if topic.closed %}
-                        <a href="{% url pybb:open_topic topic.id %}">{% trans "Open topic" %}</a> /
+                        <a href="{% url 'pybb:open_topic' topic.id %}">{% trans "Open topic" %}</a> /
                     {% else %}
-                        <a href="{% url pybb:close_topic topic.id %}">{% trans "Close topic" %}</a> /
+                        <a href="{% url 'pybb:close_topic' topic.id %}">{% trans "Close topic" %}</a> /
                     {% endif %}
                     {% if perms.pybb.change_topic and user.is_staff %}
-                        <a href="{% url admin:pybb_topic_change topic.id %}">{% trans 'Admin' %}</a> /
+                        <a href="{% url 'admin:pybb_topic_change' topic.id %}">{% trans 'Admin' %}</a> /
                     {% endif %}
                     {% comment %}
-            <a href="{% url pybb:merge_topics %}?topic={{ topic.id }}">{% trans 'Merge topics' %}</a> /
+            <a href="{% url 'pybb:merge_topics' %}?topic={{ topic.id }}">{% trans 'Merge topics' %}</a> /
             {% endcomment %}
                 {% endif %}
 
                 {% if user.is_subscribed %}
-                    <a href="{% url pybb:delete_subscription topic.id %}?from_topic">{% trans "Unsubscribe" %}</a>
+                    <a href="{% url 'pybb:delete_subscription' topic.id %}?from_topic">{% trans "Unsubscribe" %}</a>
                 {% else %}
-                    <a href="{% url pybb:add_subscription topic.id %}">{% trans "Subscribe" %}</a>
+                    <a href="{% url 'pybb:add_subscription' topic.id %}">{% trans "Subscribe" %}</a>
                 {% endif %}
             </div>
         {% endif %}
@@ -86,7 +89,7 @@
             <div class="subscriber-list">
                 {% trans "Subscribers" %}:
                 {% for subscriber in topic.subscribers.all %}
-                    <a href="{% url pybb:user subscriber.username %}">{{ subscriber.username }}</a>,
+                    <a href="{% url 'pybb:user' subscriber.username %}">{{ subscriber.username }}</a>,
                 {% endfor %}
             </div>
         {% endif %}

--- a/pybb/templates/pybb/user.html
+++ b/pybb/templates/pybb/user.html
@@ -1,4 +1,7 @@
 {% extends 'pybb/base.html' %}
+
+{% load url from future %}
+
 {% load pybb_tags i18n thumbnail %}
 
 {% block title %}{{ target_user.username }}{% endblock %}
@@ -20,7 +23,7 @@
             <div>{% trans "Number of topics" %}: {{ topic_count }}.
                 {% comment %}
                 &nbsp;
-                <a href="{% url pybb:user_topics profile.username %}">
+                <a href="{% url 'pybb:user_topics' profile.username %}">
                     {% trans "Find all topics" %}
                 </a>
                 {% endcomment %}
@@ -31,10 +34,10 @@
     </div>
     <div class='controls'>
         {% if perms.pybb.block_users %}
-            <a href='{% url pybb:block_user target_user.username %}'>{% trans 'Block' %}</a>
+            <a href='{% url 'pybb:block_user' target_user.username %}'>{% trans 'Block' %}</a>
         {% endif %}
         {% if perms.pybb.can_edit %}
-            <a href='{% url admin:pybb_profile_change target_user.pybb_profile.id %}'>{% trans 'Edit' %}</a>
+            <a href='{% url 'admin:pybb_profile_change' target_user.pybb_profile.id %}'>{% trans 'Edit' %}</a>
         {% endif %}
     </div>
 

--- a/pybb/templates/pybb/user_posts.html
+++ b/pybb/templates/pybb/user_posts.html
@@ -1,4 +1,7 @@
 {% extends 'pybb/base.html' %}
+
+{% load url from future %}
+
 {% load pybb_tags i18n %}
 
 {% block content %}
@@ -12,7 +15,7 @@
 
         <span class="post_count">{{ topic.posts.count }}</span>
         <span class="updated">{{ topic.created|date:"d M Y h:i" }}</span>
-        <a href={% url pybb_post topic.id %}>{{ topic.body_text }}</a>
+        <a href={% url 'pybb_post' topic.id %}>{{ topic.body_text }}</a>
         </li>
         {% endfor %}
 

--- a/pybb/templates/pybb/user_topics.html
+++ b/pybb/templates/pybb/user_topics.html
@@ -1,4 +1,7 @@
 {% extends 'pybb/base.html' %}
+
+{% load url from future %}
+
 {% load pybb_tags i18n %}
 
 {% block title %}{% trans "All topics created by" %} {{ profile }}{% endblock %}
@@ -10,7 +13,7 @@
         <ul class="tablist-inner topic">
             {% for topic in page.object_list %}
             <li class="tablist-inner-row topic">
-                <span class="title"><a href={% url pybb_topic topic.id %}>{{ topic }}</a></span>
+                <span class="title"><a href={% url 'pybb_topic' topic.id %}>{{ topic }}</a></span>
                 <span class="post_count">{{ topic.posts.count }}</span>
                 <span class="updated">{{ topic.created|date:"d M Y h:i" }}</span>
             </li>

--- a/test/example_bootstrap/templates/bootstrap_base.html
+++ b/test/example_bootstrap/templates/bootstrap_base.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 {% load pytils_numeral %}
 <!DOCTYPE html>
 <html>
@@ -37,23 +38,23 @@
             <ul class="nav">
                 {% if request.user.is_authenticated %}
                     <li>
-                        <a href="{% url pybb:edit_profile %}">Profile [logged as {{ request.user.username }}]</a>
+                        <a href="{% url 'pybb:edit_profile' %}">Profile [logged as {{ request.user.username }}]</a>
                     </li>
                     <li>
-                        <a href="{% url auth_logout %}">Logout</a>
+                        <a href="{% url 'auth_logout' %}">Logout</a>
                     </li>
                     {% if request.user.is_superuser %}
                         <li>
-                            <a href="{% url admin:index %}">Admin interface</a>
+                            <a href="{% url 'admin:index' %}">Admin interface</a>
                         </li>
                     {% endif %}
 
                 {% else %}
                     <li>
-                        <a href="{% url auth_login %}">Login</a>
+                        <a href="{% url 'auth_login' %}">Login</a>
                     </li>
                     <li>
-                        <a href="{% url registration_register %}">Register</a>
+                        <a href="{% url 'registration_register' %}">Register</a>
                     </li>
                 {% endif %}
                 <li><a href="http://github.com/hovel/pybbm">Code</a></li>

--- a/test/example_bootstrap/templates/registration/login.html
+++ b/test/example_bootstrap/templates/registration/login.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+
+{% load url from future %}
+
 {% block title %}
     Login
 {% endblock %}
@@ -16,7 +19,7 @@
     </form>
 
     <p>
-        <b>Don't have an account?</b> <a href="{% url registration_register %}">Register</a>
+        <b>Don't have an account?</b> <a href="{% url 'registration_register' %}">Register</a>
     </p>
 
 {% endblock %}


### PR DESCRIPTION
This pull request is for migration from old url tag format to Django 1.5 url tag format.

I used [django-future-url](https://github.com/futurecolors/django-future-url) and I have passed all the built-in tests in pybbm.
(Because it seems [original django-registration](https://bitbucket.org/ubernostrum/django-registration) has been broken for a long time, I used [a fork of django-registration](https://bitbucket.org/jscott1971/django-registration/commits/all/tip/branch%28%22cbv%22%29))
