### PR TITLE
Don't clobber markupSet from markitup/sets/{{ PYBB_MARKUP}}

### DIFF
--- a/pybb/templates/pybb/_markitup.html
+++ b/pybb/templates/pybb/_markitup.html
@@ -11,25 +11,6 @@ $(function() {
     mySettings['previewParserPath'] = '{% url 'pybb:post_ajax_preview' %}';
     mySettings['previewPosition'] = 'before';
     mySettings['resizeHandle'] = true;
-    mySettings['markupSet'] = [
-        {name:'{% trans 'Bold' %}', key:'B', openWith:'[b]', closeWith:'[/b]'},
-        {name:'{% trans 'Italic' %}', key:'I', openWith:'[i]', closeWith:'[/i]'},
-        {name:'{% trans 'Underline' %}', key:'U', openWith:'[u]', closeWith:'[/u]'},
-        {name:'{% trans 'Stroke' %}', key:'S', openWith:'[s]', closeWith:'[/s]'},
-        {separator:'---------------' },
-        {name:'{% trans 'Picture' %}', key:'P', replaceWith:'[img][![Url]!][/img]'},
-        {name:'{% trans 'Link' %}', key:'L', openWith:'[url=[![Url]!]]', closeWith:'[/url]', placeHolder:'Your text to link here...'},
-        {separator:'---------------' },
-        {name:'{% trans 'Bulleted list' %}', openWith:'[list]\n', closeWith:'\n[/list]'},
-        {name:'{% trans 'Numeric list' %}', openWith:'[list=[![Starting number]!]]\n', closeWith:'\n[/list]'},
-        {name:'{% trans 'List item' %}', openWith:'[*] '},
-        {separator:'---------------' },
-        {name:'{% trans 'Quotes' %}', openWith:'[quote]', closeWith:'[/quote]'},
-        {name:'{% trans 'Code' %}', openWith:'[code]', closeWith:'[/code]'},
-        {separator:'---------------' },
-        {name:'{% trans 'Clean' %}', className:"clean", replaceWith:function(markitup) { return markitup.selection.replace(/\[(.*?)\]/g, "") } },
-        {name:'{% trans 'Preview' %}', className:"preview", call:'preview' }
-    ];
     $('textarea:not([class="no-markitup"])').markItUp(mySettings);
 
     $('#emoticons a').click(function() {


### PR DESCRIPTION
By setting 'markupSet' here you clobber any config from markitup/sets/{{ PYBB_MARKUP}}.
This allows using a markup of non-bbcode to work, such as markdown.