### PR TITLE
testing.rst:  Remove mention of bitbucket, minor changes

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -19,6 +19,6 @@ Go to `test/example_bootstrap` or `test/example_thirdparty` directory and run::
 Extending
 ---------
 
-Development happens on bitbucket, with main repo: http://github.com/hovel/pybbm
+Development happens on github, with main repo: https://github.com/hovel/pybbm
 
-Forks, patch and pull changes ;)
+Forks, patches and pull requests live here ;)


### PR DESCRIPTION
As well as changing bitbucket -> github, I also changed http to https and re-worded the message at the end to be a little clearer.  Just a tiny change to improve the docs a little bit
