### PR TITLE
Set updated date on Post save

### DIFF
--- a/pybb/models.py
+++ b/pybb/models.py
@@ -265,6 +265,8 @@ class Post(RenderableItem):
         created_at = tznow()
         if self.created is None:
             self.created = created_at
+        else:
+            self.updated = created_at
         self.render()
 
         new = self.pk is None


### PR DESCRIPTION
The updated date of a post is never set - if it's not intentional.

This patch just set the `updated` Post field on save if it's not a creation.
