### PR TITLE
refactor topic subscribers' notification in order to optimize it

### DIFF
--- a/pybb/subscription.py
+++ b/pybb/subscription.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.core.validators import validate_email
 from django.template.loader import render_to_string
 from django.utils import translation
 from django.contrib.sites.models import Site
@@ -36,6 +37,12 @@ def notify_topic_subscribers(post):
 
         mails = tuple()
         for user in topic.subscribers.exclude(pk=post.user.pk):
+            try:
+                validate_email(user.email)
+            except:
+                # Invalid email
+                continue
+
             lang = util.get_pybb_profile(user).language or settings.LANGUAGE_CODE
             translation.activate(lang)
 


### PR DESCRIPTION
Attempt to optimize notification by:
- define context variables for templates rendering only once
- exclude post's author from the users QuerySet instead of checking it inside the loop
- use `send_mass_mail` to open only one connection to the mail server (it's also provided by django-mailer but only in the new version: https://github.com/pinax/django-mailer/blob/master/mailer/__init__.py#L78)
- remove email validation since it's normally done by the model
- reactivate `old_lang` language only once and at the end

I have also added a `user` context variable for the email body since it can be needed to make a user-personalized message, e.g. "Hi John!".

Tell me if you disagree with some of those changes or/and if they don't optimize the process!
