### PR TITLE
Make User Topics template consistent with User Posts template.

### DIFF
--- a/pybb/templates/pybb/user_topics.html
+++ b/pybb/templates/pybb/user_topics.html
@@ -12,7 +12,7 @@
 
 {% block content %}
     {% pybb_get_profile target_user as target_profile %}
-    <h1>{% trans "All topics created by" %} {{ target_profile.get_absolute_url }}</h1>
+    <h1>{% trans "All topics created by" %} <a href="{{ target_profile.get_absolute_url }}">{{ target_user.get_username }}</a></h1>
 
     {% include "pybb/pagination.html" %}
 


### PR DESCRIPTION
Currently the all topics template shows the unlinked url to user profile. Instead show the username that is linked to the user profile, similar to all posts template.
