### PR TITLE
add transaction context manager when we create a topic and a post

### DIFF
--- a/pybb/forms.py
+++ b/pybb/forms.py
@@ -6,6 +6,7 @@ import inspect
 
 from django import forms
 from django.core.exceptions import FieldError
+from django.db import transaction, connection
 from django.forms.models import inlineformset_factory, BaseInlineFormSet
 from django.utils.translation import ugettext, ugettext_lazy
 from django.utils.timezone import now as tznow
@@ -114,6 +115,7 @@ class PostForm(forms.ModelForm):
         return self.cleaned_data
 
     def save(self, commit=True):
+        commit_topic = False
         if self.instance.pk:
             post = super(PostForm, self).save(commit=False)
             if self.user:
@@ -124,11 +126,13 @@ class PostForm(forms.ModelForm):
                     post.topic.poll_type = self.cleaned_data['poll_type']
                     post.topic.poll_question = self.cleaned_data['poll_question']
                 post.topic.updated = tznow()
-                if commit:
-                    post.topic.save()
+                commit_topic = commit
             post.updated = tznow()
             if commit:
-                post.save()
+                with transaction.commit_on_success():
+                    if commit_topic:
+                        post.topic.save()
+                    post.save()
             return post
 
         allow_post = True
@@ -144,15 +148,22 @@ class PostForm(forms.ModelForm):
             )
             if not allow_post:
                 topic.on_moderation = True
-            if commit:
-                topic.save()
+            commit_topic = commit
         else:
             topic = self.topic
         post = Post(topic=topic, user=self.user, user_ip=self.ip, body=self.cleaned_data['body'])
         if not allow_post:
             post.on_moderation = True
         if commit:
-            post.save()
+            with transaction.commit_on_success():
+                if commit_topic:
+                    topic.save()
+                try:
+                    post.save()
+                except:
+                    if commit_topic and not connection.features.supports_transactions:
+                        topic.delete()
+                    raise
         return post
 
 


### PR DESCRIPTION
When a new topic is created, if an error occurs during the post's save method, we stay with DB registered topic without any post. This state is not allowed by the pybb code and forum where the topic is created is not any more viewable (there are some other case where Eceptions are raised because of a topic without post).

The post's save method can raise an error for exemple when the parser raise an Error.

To keep the database integrity, we can use DB transactions. For Databases which does not support transactions, we delete the bad topic before to re-raise the Exception.