### PR TITLE
topic without post during a really short time 

### DIFF
--- a/pybb/models.py
+++ b/pybb/models.py
@@ -175,7 +175,7 @@ class Topic(models.Model):
 
     def save(self, *args, **kwargs):
         if self.id is None:
-            self.created = tznow()
+            self.created = self.updated = tznow()
 
         forum_changed = False
         old_topic = None

--- a/pybb/tests.py
+++ b/pybb/tests.py
@@ -181,6 +181,9 @@ class FeaturesTest(TestCase, SharedTestModule):
         #before correction, raised TypeError: can't compare datetime.datetime to NoneType
         pybb_topic_unread([topic,], user_ann)
         
+        #before correction, raised IndexError: list index out of range
+        last_post = topic.last_post
+        
         #post creation now.
         Post(topic=topic, user=self.user, body='one').save()
         

--- a/pybb/tests.py
+++ b/pybb/tests.py
@@ -151,6 +151,45 @@ class FeaturesTest(TestCase, SharedTestModule):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(Topic.objects.filter(name='new topic name').exists())
 
+    def test_topic_read_before_post_addition(self):
+        """
+        Test if everything is okay when :
+            - user A create the topic
+            - but before associated post is created, user B display the forum
+        """
+        topic = Topic(name='xtopic', forum=self.forum, user=self.user)
+        topic.save()
+        #topic is saved, but post is not yet created at this time
+
+        #an other user is displaing the forum before the post creation
+        user_ann = User.objects.create_user('ann', 'ann@localhost', 'ann')
+        client = Client()
+        client.login(username='ann', password='ann')
+
+        self.assertEqual(client.get(topic.get_absolute_url()).status_code, 404)
+        self.assertEqual(topic.forum.post_count, 1)
+        self.assertEqual(topic.forum.topic_count, 1)
+        #do we need to correct this ?
+        #self.assertEqual(topic.forum.topics.count(), 1)
+        self.assertEqual(topic.post_count, 0)
+        
+        #Now, TopicReadTracker is not created because the topic detail view raise a 404
+        #If its creation is not finished. So we create it manually to add a test, just in case
+        #we have an other way where TopicReadTracker could be set for a not complete topic.
+        TopicReadTracker.objects.create(user=user_ann, topic=topic, time_stamp=topic.created)
+        
+        #before correction, raised TypeError: can't compare datetime.datetime to NoneType
+        pybb_topic_unread([topic,], user_ann)
+        
+        #post creation now.
+        Post(topic=topic, user=self.user, body='one').save()
+        
+        self.assertEqual(client.get(topic.get_absolute_url()).status_code, 200)
+        self.assertEqual(topic.forum.post_count, 2)
+        self.assertEqual(topic.forum.topic_count, 2)
+        self.assertEqual(topic.forum.topics.count(), 2)
+        self.assertEqual(topic.post_count, 1)
+
     def test_post_deletion(self):
         post = Post(topic=self.topic, user=self.user, body='bbcode [b]test[/b]')
         post.save()
@@ -1017,6 +1056,7 @@ class AnonymousTest(TestCase, SharedTestModule):
         self.category = Category.objects.create(name='foo')
         self.forum = Forum.objects.create(name='xfoo', description='bar', category=self.category)
         self.topic = Topic.objects.create(name='etopic', forum=self.forum, user=self.user)
+        self.post = Post.objects.create(body='body post', topic=self.topic, user=self.user)
         add_post_permission = Permission.objects.get_by_natural_key('add_post', 'pybb', 'post')
         self.user.user_permissions.add(add_post_permission)
 

--- a/pybb/views.py
+++ b/pybb/views.py
@@ -163,7 +163,11 @@ class TopicView(RedirectToLoginMixin, PaginatorMixin, generic.ListView):
 
     @method_decorator(csrf_protect)
     def dispatch(self, request, *args, **kwargs):
-        self.topic = get_object_or_404(Topic.objects.select_related('forum'), pk=kwargs['pk'])
+        self.topic = get_object_or_404(
+            Topic.objects.select_related('forum'), 
+            pk=kwargs['pk'], 
+            post_count__gt=0
+        )
 
         if request.GET.get('first-unread'):
             if request.user.is_authenticated():

--- a/test/test_project/templates/404.html
+++ b/test/test_project/templates/404.html
@@ -1,0 +1,4 @@
+<html>
+<head><title>404</title></head>
+<body>404 template for Django 1.4</body>
+</html>


### PR DESCRIPTION
When a topic is created, it's in two step :
* topic creation (`updated` field is None at this moment)
* then, post creation
    * topic update : `post_count` and `updated` fields
    * forum update

A use was able to display the topic detail page between those 2 steps and had a topic without post. It the template tag "pybb_topic_unread" was called after this display but before the second step of topic creation, an exception was raised `can't compare datetime.datetime to NoneType` because topic 's `updated` field is still `None`

This pull add two changements :
* A topic detail now raise a 404 if the topic is not yet fully created (mean : has not yet post_count greater than 0)
* The topic's `updated` field is now set with the `created` field. This correction is not necessary because of the first one, but I prefer add it to avoid some futur identical bug.

Of course, Tests are added.

One question is still in suspend : 
* do `forum.topics.all()` must return topics without post or do we need to add a default ModelManager which return only "valid" topics ?

This pull requests is related to issue #147 