### PR TITLE
New feature + tests: Grant moderator privileges form

### DIFF
--- a/pybb/admin.py
+++ b/pybb/admin.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8
 from __future__ import unicode_literals
+from copy import deepcopy
 from django.utils.translation import ugettext_lazy as _
 from django.contrib import admin
 from django.core.urlresolvers import reverse
@@ -48,14 +49,17 @@ class ForumAdmin(admin.ModelAdmin):
             ),
         )
 
-    def get_form(self, request, obj=None, **kwargs):
+    def get_fieldsets(self, request, obj=None):
         """
         adds moderators field to Additionnal options fieldset only if
         the request user has permission to manage moderators
         """
+
+        fieldsets = super(ForumAdmin, self).get_fieldsets(request, obj)
         if permissions.perms.may_manage_moderators(request.user):
-            self.fieldsets[1][1]['fields'] += ('moderators',)
-        return super(ForumAdmin, self).get_form(request, obj, **kwargs)
+            fieldsets = deepcopy(fieldsets)
+            fieldsets[-1][1]['fields'] += ('moderators',)
+        return fieldsets
 
 
 class PollAnswerAdmin(admin.TabularInline):

--- a/pybb/admin.py
+++ b/pybb/admin.py
@@ -4,6 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.contrib import admin
 from django.core.urlresolvers import reverse
 
+from pybb import permissions
 from pybb.models import Category, Forum, Topic, Post, Profile, Attachment, PollAnswer
 
 from pybb import compat, util
@@ -42,10 +43,19 @@ class ForumAdmin(admin.ModelAdmin):
          ),
         (_('Additional options'), {
                 'classes': ('collapse',),
-                'fields': ('updated', 'description', 'headline', 'post_count', 'moderators', 'slug')
+                'fields': ('updated', 'description', 'headline', 'post_count', 'slug')
                 }
             ),
         )
+
+    def get_form(self, request, obj=None, **kwargs):
+        """
+        adds moderators field to Additionnal options fieldset only if
+        the request user has permission to manage moderators
+        """
+        if permissions.perms.may_manage_moderators(request.user):
+            self.fieldsets[1][1]['fields'] += ('moderators',)
+        return super(ForumAdmin, self).get_form(request, obj, **kwargs)
 
 
 class PollAnswerAdmin(admin.TabularInline):

--- a/pybb/forms.py
+++ b/pybb/forms.py
@@ -10,9 +10,8 @@ from django.forms.models import inlineformset_factory, BaseInlineFormSet
 from django.utils.translation import ugettext, ugettext_lazy
 from django.utils.timezone import now as tznow
 
-from pybb import compat, defaults, util
+from pybb import compat, defaults, util, permissions
 from pybb.models import Topic, Post, Attachment, PollAnswer, Category
-from pybb.permissions import perms
 
 
 User = compat.get_user_model()
@@ -272,8 +271,10 @@ class ModeratorForm(forms.Form):
         super(ModeratorForm, self).__init__(*args, **kwargs)
         categories = Category.objects.all()
         self.authorized_forums = []
+        if not permissions.perms.may_manage_moderators(user):
+            raise PermissionDenied()
         for category in categories:
-            forums = [forum.pk for forum in category.forums.all() if perms.may_change_forum(user, forum)]
+            forums = [forum.pk for forum in category.forums.all() if permissions.perms.may_change_forum(user, forum)]
             if forums:
                 self.authorized_forums += forums
                 self.fields['cat_%d' % category.pk] = forms.ModelMultipleChoiceField(
@@ -282,8 +283,6 @@ class ModeratorForm(forms.Form):
                     widget=forms.CheckboxSelectMultiple(),
                     required=False
                 )
-        if not self.fields:
-            raise PermissionDenied()
 
     def process(self, target_user):
         """
@@ -299,4 +298,3 @@ class ModeratorForm(forms.Form):
         # keep all the forums, the request user does't have the permisssion to change
         untouchable_forums = [forum for forum in initial_forum_set if forum.pk not in self.authorized_forums]
         target_user.forum_set = checked_forums + untouchable_forums
-

--- a/pybb/forms.py
+++ b/pybb/forms.py
@@ -262,7 +262,7 @@ class ModeratorForm(forms.Form):
     def __init__(self, user, *args, **kwargs):
 
         """
-        Create the form to grant moderator privileges, checking if the request user has the 
+        Creates the form to grant moderator privileges, checking if the request user has the
         permission to do so.
 
         :param user: request user

--- a/pybb/permissions.py
+++ b/pybb/permissions.py
@@ -187,5 +187,11 @@ class DefaultPermissionHandler(object):
         """
         return False
 
+    def may_change_forum(self, user, forum):
+        """
+        Returns True if the user has the permissions to add modertors to a forum
+        By default True if user can change forum
+        """
+        return user.is_superuser or user.has_perm('pybb.change_forum')
 
 perms = util.resolve_class(defaults.PYBB_PERMISSION_HANDLER)

--- a/pybb/permissions.py
+++ b/pybb/permissions.py
@@ -194,4 +194,8 @@ class DefaultPermissionHandler(object):
         """
         return user.is_superuser or user.has_perm('pybb.change_forum')
 
+    def may_manage_moderators(self, user):
+        """ return True if `user` may manage moderators"""
+        return user.is_staff
+
 perms = util.resolve_class(defaults.PYBB_PERMISSION_HANDLER)

--- a/pybb/permissions.py
+++ b/pybb/permissions.py
@@ -196,6 +196,6 @@ class DefaultPermissionHandler(object):
 
     def may_manage_moderators(self, user):
         """ return True if `user` may manage moderators"""
-        return user.is_staff
+        return user.is_superuser or user.is_staff
 
 perms = util.resolve_class(defaults.PYBB_PERMISSION_HANDLER)

--- a/pybb/templates/pybb/edit_privileges.html
+++ b/pybb/templates/pybb/edit_privileges.html
@@ -1,0 +1,21 @@
+{% extends 'pybb/base.html' %}
+
+{% load url from future %}
+
+{% load i18n pybb_tags %}
+
+{% block title %}{% trans "Grant moderator privileges" %}{% endblock title %}
+
+{% block content %}
+    <h1>{% trans "Grant moderator privileges" %}</h1>
+        <form method="post" action="" class="privileges-edit">
+            {% csrf_token %}
+            <fieldset>
+                {% for field in form %}
+                    <h3>{{ field.label }} : </h3>
+                    {{ field }}
+                {% endfor %}
+            </fieldset>
+            <p>{% include "pybb/_button_save.html" %}</p>
+        </form>
+{% endblock content %}

--- a/pybb/templates/pybb/user.html
+++ b/pybb/templates/pybb/user.html
@@ -33,6 +33,9 @@
         <div class="clear"></div>
     </div>
     <div class='controls'>
+        {% if request.user|pybb_may_change_forum:"" %}
+            <a href="{% url 'pybb:edit_privileges' target_user.get_username %}" class="btn">{% trans 'Moderator' %}</a>
+        {% endif %}
         {% if perms.pybb.block_users %}
             {% if target_user.is_active %}
                 <form action="{% url 'pybb:block_user' target_user.get_username %}" method="post">{% csrf_token %}

--- a/pybb/templates/pybb/user.html
+++ b/pybb/templates/pybb/user.html
@@ -33,7 +33,7 @@
         <div class="clear"></div>
     </div>
     <div class='controls'>
-        {% if request.user|pybb_may_change_forum:"" %}
+        {% if request.user|pybb_may_manage_moderators %}
             <a href="{% url 'pybb:edit_privileges' target_user.get_username %}" class="btn">{% trans 'Moderator' %}</a>
         {% endif %}
         {% if perms.pybb.block_users %}

--- a/pybb/tests.py
+++ b/pybb/tests.py
@@ -1134,6 +1134,10 @@ class FeaturesTest(TestCase, SharedTestModule):
                 )
             )
 
+        # test the permission to acces the page
+        response = self.client.get(reverse('pybb:edit_privileges', kwargs={'username': self.user.username}))
+        self.assertEqual(response.status_code, 403)
+
         add_moderator_permission = Permission.objects.get_by_natural_key('change_forum','pybb','forum')
         self.user.user_permissions.add(add_moderator_permission)
 
@@ -1150,7 +1154,6 @@ class FeaturesTest(TestCase, SharedTestModule):
                 )
             )
 
-        # test the permission to acces the page
         response = self.client.get(reverse('pybb:edit_privileges', kwargs={'username': moderator.username}))
         self.assertEqual(response.status_code, 200)
 

--- a/pybb/tests.py
+++ b/pybb/tests.py
@@ -1164,7 +1164,9 @@ class FeaturesTest(TestCase, SharedTestModule):
         response = self.client.post(
             reverse('pybb:edit_privileges', kwargs={'username': moderator.username}), data=values, follow=True)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual([self.forum, forum2], [forum for forum in moderator.forum_set.all()])
+        correct_list = sorted([self.forum, forum2], key=lambda forum: forum.pk)
+        moderator_list = sorted([forum for forum in moderator.forum_set.all()], key=lambda forum: forum.pk)
+        self.assertEqual(correct_list, moderator_list)
 
         # test to remove user as moderator
         values['cat_%d' % self.category.pk] = [self.forum.pk, ]

--- a/pybb/urls.py
+++ b/pybb/urls.py
@@ -12,7 +12,7 @@ from pybb.views import IndexView, CategoryView, ForumView, TopicView,\
     AddPostView, EditPostView, UserView, PostView, ProfileEditView,\
     DeletePostView, StickTopicView, UnstickTopicView, CloseTopicView,\
     OpenTopicView, ModeratePost, TopicPollVoteView, LatestTopicsView,\
-    UserTopics, UserPosts, topic_cancel_poll_vote
+    UserTopics, UserPosts, topic_cancel_poll_vote, UserEditPrivilegesView
 
 
 urlpatterns = patterns('',
@@ -33,6 +33,7 @@ urlpatterns += patterns('pybb.views',
                         url('^unblock_user/([^/]+)/$', 'unblock_user', name='unblock_user'),
                         url(r'^users/(?P<username>[^/]+)/topics/$', UserTopics.as_view(), name='user_topics'),
                         url(r'^users/(?P<username>[^/]+)/posts/$', UserPosts.as_view(), name='user_posts'),
+                        url(r'^users/(?P<username>[^/]+)/edit-privileges/$', UserEditPrivilegesView.as_view(), name='edit_privileges'),
 
                         # Profile
                         url('^profile/edit/$', ProfileEditView.as_view(), name='edit_profile'),


### PR DESCRIPTION
The only way to add a moderator is to add a user id to the forum's moderator list in the django admin which is not an easy method for lambda users.
It also has the issue to make you go through all the forums to a add the same moderator.

That pull adds a form accessible from a user profile to grant him moderator privileges:

* It adds a new permission may_manage_forum that checks if a user has change_forum permission.
* Before displaying it checks the permission on every forum, so it adds the possibility to have different permissions on every forum.
* It allows you to add/remove a moderator to multiple forums in a few clicks