### PR TITLE
Easy thumbnails fix

### DIFF
--- a/pybb/templates/pybb/avatar.html
+++ b/pybb/templates/pybb/avatar.html
@@ -10,11 +10,16 @@
                 <img src="{{PYBB_DEFAULT_AVATAR_URL}}" alt="default avatar" />
             {% endthumbnail %}
         {% else %}
-            {% if user_profile.avatar %}
-                <img src="{{ user_profile.avatar.url }}" alt="{{ user_profile.get_display_name }} avatar" width="{{ PYBB_AVATAR_WIDTH }}" height="{{ PYBB_AVATAR_HEIGHT }}" />
+            {% if_has_tag thumbnail %}
+                {% thumbnail user_profile.avatar|default:PYBB_DEFAULT_AVATAR_URL PYBB_AVATAR_DIMENSIONS as avatar %}
+                <img src="{{ avatar.url }}" alt="{{ user_profile.get_display_name }} avatar" />
             {% else %}
-                <img src="{{PYBB_DEFAULT_AVATAR_URL}}" alt="default avatar" width="{{ PYBB_AVATAR_WIDTH }}" height="{{ PYBB_AVATAR_HEIGHT }}" />
-            {% endif %}
+                {% if user_profile.avatar %}
+                    <img src="{{ user_profile.avatar.url }}" alt="{{ user_profile.get_display_name }} avatar" width="{{ PYBB_AVATAR_WIDTH }}" height="{{ PYBB_AVATAR_HEIGHT }}" />
+                {% else %}
+                    <img src="{{PYBB_DEFAULT_AVATAR_URL}}" alt="default avatar" width="{{ PYBB_AVATAR_WIDTH }}" height="{{ PYBB_AVATAR_HEIGHT }}" />
+                {% endif %}
+            {% endif_has_tag %}
         {% endif_has_tag %}
     </a>
 </div>

--- a/pybb/templates/pybb/avatar.html
+++ b/pybb/templates/pybb/avatar.html
@@ -3,7 +3,7 @@
 <div class="avatar">
     {% pybb_get_profile user=user as user_profile %}
     <a href="{{ user_profile.get_absolute_url }}">
-        {% if_has_tag thumbnail %}
+        {% if_has_tag thumbnail empty %}
             {% thumbnail user_profile.avatar PYBB_AVATAR_DIMENSIONS as avatar %}
                 <img src="{{ avatar.url }}" alt="{{ user_profile.get_display_name }} avatar" />
             {% empty %}


### PR DESCRIPTION
Fixes #171 but leaves #160.  I am inclined to agree with @GeyseR that file deletion should be left to the implementer.  There are so many ways of storing static files, filesystem, s3, mongo, etc.  I suppose you could implement it for the default avatar field in PybbProfile, but I don't know how many people will be using the default profile without overriding it, and off the top of my head I don't know how you would check for that.