### PR TITLE
Fix example bootstrap

### DIFF
--- a/test/example_bootstrap/requirements.txt
+++ b/test/example_bootstrap/requirements.txt
@@ -1,5 +1,8 @@
 django>=1.7,<1.8
 
+#required to use with django<1.7
+#south
+
 #exemple_bootstrap dependencies
 django-registration-redux
 

--- a/test/example_bootstrap/requirements.txt
+++ b/test/example_bootstrap/requirements.txt
@@ -12,5 +12,5 @@ bbcode
 Pillow>=2.7,<2.8
 
 #for test purpose only
-lxml
-markdown
+#lxml
+#markdown

--- a/test/example_bootstrap/requirements.txt
+++ b/test/example_bootstrap/requirements.txt
@@ -1,7 +1,7 @@
-django>=1.6,<1.7
+django>=1.7,<1.8
 
 #exemple_bootstrap dependencies
-django-registration
+django-registration-redux
 
 #pybb strong dependencies
 django-annoying
@@ -9,5 +9,5 @@ bbcode
 Pillow>=2.7,<2.8
 
 #for test purpose only
-#lxml
-#markdown
+lxml
+markdown

--- a/test/example_bootstrap/settings.py
+++ b/test/example_bootstrap/settings.py
@@ -4,6 +4,7 @@ DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
 import os
+import django
 
 PROJECT_ROOT = os.path.dirname(os.path.realpath(__file__))
 
@@ -50,7 +51,6 @@ MIDDLEWARE_CLASSES = (
     'pybb.middleware.PybbMiddleware',
 )
 
-ROOT_URLCONF = 'example_bootstrap.urls'
 
 TEMPLATE_DIRS = (
     os.path.join(PROJECT_ROOT, 'templates'),
@@ -67,6 +67,9 @@ INSTALLED_APPS = (
     'pybb',
     'registration'
 )
+
+if django.VERSION < (1, 7):
+    INSTALLED_APPS += ('south',)
 
 TEMPLATE_CONTEXT_PROCESSORS = (
     'django.contrib.auth.context_processors.auth',
@@ -100,4 +103,5 @@ LOGGING = {
     }
 }
 
+ROOT_URLCONF = 'urls'
 PYBB_ATTACHMENT_ENABLE = False


### PR DESCRIPTION
It was not possible to run tests using the example bootstrap project (as recommended in the readme) without some modifications. 