### PR TITLE
Fix python 3 bug

### DIFF
--- a/pybb/templatetags/pybb_tags.py
+++ b/pybb/templatetags/pybb_tags.py
@@ -202,7 +202,7 @@ def pybb_topic_inline_pagination(topic):
     page_count = int(math.ceil(topic.post_count / float(defaults.PYBB_TOPIC_PAGE_SIZE)))
     if page_count <= 5:
         return range(1, page_count+1)
-    return range(1, 5) + ['...', page_count]
+    return list(range(1, 5)) + ['...', page_count]
 
 
 @register.filter


### PR DESCRIPTION
In python 3 range is now a generator (like xrange was - there is no xrange in python 3)

Currently this throws an TypeError unsupported operand + for type and list

Casting range to a list works for both python 2 and 3