### PR TITLE
Remove null=True from 'created' fields and add auto_now_add.

### DIFF
--- a/pybb/migrations/0005_auto_now_add_created.py
+++ b/pybb/migrations/0005_auto_now_add_created.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from django.conf import settings
 from django.db import models, migrations
+from django.utils.timezone import make_aware
 import datetime
 
 
@@ -9,11 +11,14 @@ def forwards_func(apps, schema_editor):
     Topic = apps.get_model("pybb", "Topic")
     Post = apps.get_model("pybb", "Post")
     db_alias = schema_editor.connection.alias
+    min_datetime = datetime.datetime.min
+    if settings.USE_TZ:
+        min_datetime = make_aware(min_datetime)
     Topic.objects.using(db_alias).filter(created=None).update(
-        created=datetime.datetime.min
+        created=min_datetime
     )
     Post.objects.using(db_alias).filter(created=None).update(
-        created=datetime.datetime.min
+        created=min_datetime
     )
 
 def noop(apps, schema_editor):

--- a/pybb/migrations/0005_auto_now_add_created.py
+++ b/pybb/migrations/0005_auto_now_add_created.py
@@ -16,6 +16,9 @@ def forwards_func(apps, schema_editor):
         created=datetime.datetime.min
     )
 
+def noop(apps, schema_editor):
+    pass
+
 
 class Migration(migrations.Migration):
 
@@ -26,7 +29,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunPython(
             forwards_func,
-            migrations.RunPython.noop
+            noop
         ),
         migrations.AlterField(
             model_name='post',

--- a/pybb/migrations/0005_auto_now_add_created.py
+++ b/pybb/migrations/0005_auto_now_add_created.py
@@ -26,6 +26,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunPython(
             forwards_func,
+            migrations.RunPython.noop
         ),
         migrations.AlterField(
             model_name='post',

--- a/pybb/migrations/0005_auto_now_add_created.py
+++ b/pybb/migrations/0005_auto_now_add_created.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+
+
+def forwards_func(apps, schema_editor):
+    Topic = apps.get_model("pybb", "Topic")
+    Post = apps.get_model("pybb", "Post")
+    db_alias = schema_editor.connection.alias
+    Topic.objects.using(db_alias).filter(created=None).update(
+        created=datetime.datetime.min
+    )
+    Post.objects.using(db_alias).filter(created=None).update(
+        created=datetime.datetime.min
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pybb', '0004_slugs_required'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            forwards_func,
+        ),
+        migrations.AlterField(
+            model_name='post',
+            name='created',
+            field=models.DateTimeField(auto_now_add=True, verbose_name='Created', db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='topic',
+            name='created',
+            field=models.DateTimeField(verbose_name='Created', auto_now_add=True),
+            preserve_default=False,
+        ),
+    ]

--- a/pybb/models.py
+++ b/pybb/models.py
@@ -186,11 +186,12 @@ class Topic(models.Model):
         return reverse('pybb:topic', kwargs={'pk': self.id})
 
     def save(self, *args, **kwargs):
+        if self.id is None:
+            self.updated = tznow()
 
         forum_changed = False
         old_topic = None
         if self.id is not None:
-            self.updated = tznow()
             old_topic = Topic.objects.get(id=self.id)
             if self.forum != old_topic.forum:
                 forum_changed = True
@@ -212,6 +213,8 @@ class Topic(models.Model):
             del self.last_post
         if self.last_post:
             self.updated = self.last_post.updated or self.last_post.created
+        else:
+            self.updated = self.created
         self.save()
 
     def get_parents(self):

--- a/pybb/tests.py
+++ b/pybb/tests.py
@@ -557,8 +557,8 @@ class FeaturesTest(TestCase, SharedTestModule):
 
         topic_1 = Topic.objects.get(id=topic_1.id)
         topic_2 = Topic.objects.get(id=topic_2.id)
-        self.assertEqual(topic_1.updated, post.updated or post.created)
-        self.assertEqual(forum_1.updated, post.updated or post.created)
+        self.assertAlmostEqual(topic_1.updated, post.updated or post.created, delta=datetime.timedelta(milliseconds=50))
+        self.assertAlmostEqual(forum_1.updated, post.updated or post.created, delta=datetime.timedelta(milliseconds=50))
         self.assertListEqual([t.unread for t in pybb_topic_unread([topic_1, topic_2], user_ann)], [True, False])
         self.assertListEqual([t.unread for t in pybb_forum_unread([forum_1, forum_2], user_ann)], [True, False])
 
@@ -569,8 +569,8 @@ class FeaturesTest(TestCase, SharedTestModule):
         topic_2 = Topic.objects.get(id=topic_2.id)
         forum_1 = Forum.objects.get(id=forum_1.id)
         forum_2 = Forum.objects.get(id=forum_2.id)
-        self.assertEqual(topic_2.updated, post.updated or post.created)
-        self.assertEqual(forum_2.updated, post.updated or post.created)
+        self.assertAlmostEqual(topic_2.updated, post.updated or post.created, delta=datetime.timedelta(milliseconds=50))
+        self.assertAlmostEqual(forum_2.updated, post.updated or post.created, delta=datetime.timedelta(milliseconds=50))
         self.assertListEqual([t.unread for t in pybb_topic_unread([topic_1, topic_2], user_ann)], [False, True])
         self.assertListEqual([t.unread for t in pybb_forum_unread([forum_1, forum_2], user_ann)], [False, True])
 
@@ -581,7 +581,7 @@ class FeaturesTest(TestCase, SharedTestModule):
         topic_2 = Topic.objects.get(id=topic_2.id)
         forum_1 = Forum.objects.get(id=forum_1.id)
         forum_2 = Forum.objects.get(id=forum_2.id)
-        self.assertEqual(forum_1.updated, post.updated or post.created)
+        self.assertAlmostEqual(forum_1.updated, post.updated or post.created, delta=datetime.timedelta(milliseconds=50))
         self.assertListEqual([t.unread for t in pybb_topic_unread([topic_1, topic_2], user_ann)], [False, True])
         self.assertListEqual([t.unread for t in pybb_forum_unread([forum_1, forum_2], user_ann)], [True, False])
 
@@ -615,18 +615,16 @@ class FeaturesTest(TestCase, SharedTestModule):
         self.assertRedirects(response, '%s?page=%d#post-%d' % (topic_1.get_absolute_url(), 1, post_1_3.id))
 
     def test_latest_topics(self):
-        topic_1 = self.topic
-        topic_1.updated = timezone.now()
-        topic_1.save()
-        topic_2 = Topic.objects.create(name='topic_2', forum=self.forum, user=self.user)
-        topic_2.updated = timezone.now() + datetime.timedelta(days=-1)
-        topic_2.save()
 
         category_2 = Category.objects.create(name='cat2')
         forum_2 = Forum.objects.create(name='forum_2', category=category_2)
         topic_3 = Topic.objects.create(name='topic_3', forum=forum_2, user=self.user)
-        topic_3.updated = timezone.now() + datetime.timedelta(days=-2)
-        topic_3.save()
+
+        topic_2 = Topic.objects.create(name='topic_2', forum=self.forum, user=self.user)
+
+        topic_1 = self.topic
+        topic_1.updated = timezone.now()
+        topic_1.save()
 
         self.login_client()
         response = self.client.get(reverse('pybb:topic_latest'))
@@ -1030,19 +1028,19 @@ class FeaturesTest(TestCase, SharedTestModule):
         post_1 = Post.objects.create(topic=topic_1, user=self.user, body='test')
         post_1 = Post.objects.get(id=post_1.id)
 
-        self.assertEqual(topic_1.updated, post_1.created)
-        self.assertEqual(forum_1.updated, post_1.created)
+        self.assertAlmostEqual(topic_1.updated, post_1.created, delta=datetime.timedelta(milliseconds=50))
+        self.assertAlmostEqual(forum_1.updated, post_1.created, delta=datetime.timedelta(milliseconds=50))
 
         topic_2 = Topic.objects.create(name='another topic', forum=forum_1, user=self.user)
         post_2 = Post.objects.create(topic=topic_2, user=self.user, body='another test')
         post_2 = Post.objects.get(id=post_2.id)
 
-        self.assertEqual(topic_2.updated, post_2.created)
-        self.assertEqual(forum_1.updated, post_2.created)
+        self.assertAlmostEqual(topic_2.updated, post_2.created, delta=datetime.timedelta(milliseconds=50))
+        self.assertAlmostEqual(forum_1.updated, post_2.created, delta=datetime.timedelta(milliseconds=50))
 
         topic_2.delete()
         forum_1 = Forum.objects.get(id=forum_1.id)
-        self.assertEqual(forum_1.updated, post_1.created)
+        self.assertAlmostEqual(forum_1.updated, post_1.created, delta=datetime.timedelta(milliseconds=50))
         self.assertEqual(forum_1.topic_count, 1)
         self.assertEqual(forum_1.post_count, 1)
 

--- a/pybb/tests.py
+++ b/pybb/tests.py
@@ -613,7 +613,7 @@ class FeaturesTest(TestCase, SharedTestModule):
         topic_2 = Topic.objects.create(name='topic_2', forum=self.forum, user=self.user)
 
         topic_1 = self.topic
-        topic_1.updated = timezone.now()
+        topic_1.updated = timezone.now() + datetime.timedelta(seconds=1)
         topic_1.save()
 
         self.login_client()


### PR DESCRIPTION
null=True does not make sense for a created timestamp (everything is created sometime), and it is preferred to call auto_now_add rather than using the save method to set the created timestamp because the save method is not always called, e.g. when loading objects from fixtures or when using bulk_create.

Also, this branch is a WIP of cleaning up code: I think it would be better if posts, forums and topics didn't have to worry about keeping track of their last updated time and number of posts, it would be easier and more reliable to let django+db do it.  For example, at the minute posts are responsible for calling up to their parents to update counters, and the update_counters method does more than just update counters (at the very least this method needs to be renamed or split in two).

I am working on it for my own project, let me know if you would like me to keep submitting PRs with "improvements", or if you just want a big PR when it's done, or if you don't want to make changes to these things in this repo (perfectly understandable, I can see stability is a priority)
