### PR TITLE
Drop support for old unsupported versions of Django.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,6 @@ env:
   - DJANGO="Django>=1.4,<1.5" DB=sqlite
   - DJANGO="Django>=1.4,<1.5" DB=postgres
   - DJANGO="Django>=1.4,<1.5" DB=mysql
-  - DJANGO="Django>=1.5,<1.6" DB=sqlite
-  - DJANGO="Django>=1.5,<1.6" DB=postgres
-  - DJANGO="Django>=1.5,<1.6" DB=mysql
-  - DJANGO="Django>=1.6,<1.7" DB=sqlite
-  - DJANGO="Django>=1.6,<1.7" DB=postgres
-  - DJANGO="Django>=1.6,<1.7" DB=mysql
   - DJANGO="Django>=1.7,<1.8" DB=sqlite
   - DJANGO="Django>=1.7,<1.8" DB=postgres
   - DJANGO="Django>=1.7,<1.8" DB=mysql
@@ -42,10 +36,6 @@ matrix:
       env: DJANGO="Django>=1.4,<1.5" DB=mysql
 
     - python: "3.2"
-      env: DJANGO="Django>=1.5,<1.6" DB=mysql
-    - python: "3.2"
-      env: DJANGO="Django>=1.6,<1.7" DB=mysql
-    - python: "3.2"
       env: DJANGO="Django>=1.7,<1.8" DB=mysql
     - python: "3.2"
       env: DJANGO="Django>=1.8,<1.9" DB=mysql
@@ -60,4 +50,3 @@ install:
   - CFLAGS="-O0" pip install -qU -r test/test_project/requirements_test.txt
 script:
   - python setup.py test
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-django14, {py27,py34}-django1{5,6,7,8}
+envlist = py27-django14, {py27,py34}-django1{7,8}
 
 [testenv]
 commands = {envpython} setup.py test
@@ -9,7 +9,5 @@ basepython =
 deps =
     -rtest/test_project/requirements_test.txt
     django14: Django>=1.4,<1.5
-    django15: Django>=1.5,<1.6
-    django16: Django>=1.6,<1.7
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9


### PR DESCRIPTION
Django versions 1.5 and 1.6 have been unsupported for at least a year, and anyone running them will have gaping security holes in their site, unless they have been backporting security fixes from supported versions, which seems like more work than just upgrading.

Also I think if somebody is not updating Django from 1.5 or 1.6, they aren't updating pybbm either, so there's really no need to waste time and CPU cycles running tests against those versions.