### PR TITLE
Move 'mark_read' call out of 'get_context_data' and into 'get'.

### DIFF
--- a/pybb/tests.py
+++ b/pybb/tests.py
@@ -226,6 +226,7 @@ class FeaturesTest(TestCase, SharedTestModule):
         post = Post.objects.get(id=post.id)
         self.assertTrue(self.forum.updated == post.created)
 
+    @skipUnlessDBFeature('supports_microsecond_precision')
     def test_read_tracking(self):
         topic = Topic(name='xtopic', forum=self.forum, user=self.user)
         topic.save()

--- a/pybb/views.py
+++ b/pybb/views.py
@@ -267,8 +267,7 @@ class TopicView(RedirectToLoginMixin, PaginatorMixin, PybbFormsMixin, generic.Li
         if defaults.PYBB_NICE_URL and 'pk' in kwargs:
             return redirect(self.topic, permanent=defaults.PYBB_NICE_URL_PERMANENT_REDIRECT)
         response = super(TopicView, self).get(request, *args, **kwargs)
-        if self.request.user.is_authenticated():
-            self.mark_read()
+        self.mark_read()
         return response
 
     def get_login_redirect_url(self):
@@ -355,7 +354,10 @@ class TopicView(RedirectToLoginMixin, PaginatorMixin, PybbFormsMixin, generic.Li
 
         return ctx
 
+    @method_decorator(get_atomic_func())
     def mark_read(self):
+        if not self.request.user.is_authenticated():
+            return
         try:
             forum_mark = ForumReadTracker.objects.get(forum=self.topic.forum, user=self.request.user)
         except ForumReadTracker.DoesNotExist:

--- a/pybb/views.py
+++ b/pybb/views.py
@@ -360,8 +360,7 @@ class TopicView(RedirectToLoginMixin, PaginatorMixin, PybbFormsMixin, generic.Li
             forum_mark = ForumReadTracker.objects.get(forum=self.topic.forum, user=self.request.user)
         except ForumReadTracker.DoesNotExist:
             forum_mark = None
-        if (forum_mark is None) or (forum_mark.time_stamp <= self.topic.updated):
-            # Mark topic as readed
+        if (forum_mark is None) or (forum_mark.time_stamp < self.topic.updated):
             topic_mark, new = TopicReadTracker.objects.get_or_create_tracker(topic=self.topic, user=self.request.user)
             if not new and topic_mark.time_stamp > self.topic.updated:
                 # Bail early if we already read this thread.
@@ -375,7 +374,7 @@ class TopicView(RedirectToLoginMixin, PaginatorMixin, PybbFormsMixin, generic.Li
                 unread = unread.filter(updated__gte=forum_mark.time_stamp)
 
             if not unread.exists():
-                # Clear all topic marks for this forum, mark forum as readed
+                # Clear all topic marks for this forum, mark forum as read
                 TopicReadTracker.objects.filter(user=self.request.user, topic__forum=self.topic.forum).delete()
                 forum_mark, new = ForumReadTracker.objects.get_or_create_tracker(
                     forum=self.topic.forum, user=self.request.user)


### PR DESCRIPTION
Two reasons for moving the method call:
1. I wouldn't expect 'get_context_data' to have side effects.
2. It ensures that the view returns without error before marking the topic read

This PR also modifies an inefficient query in `mark_read` that checks for unread topics in forum.
