### PR TITLE
Purges admin post form that allowed staff to post with any username, …

### DIFF
--- a/pybb/forms.py
+++ b/pybb/forms.py
@@ -168,35 +168,6 @@ class PostForm(forms.ModelForm):
         return post, topic
 
 
-class AdminPostForm(PostForm):
-    """
-    Superusers can post messages from any user and from any time
-    If no user with specified name - new user will be created
-    """
-    login = forms.CharField(label=ugettext_lazy('User'))
-
-    def __init__(self, *args, **kwargs):
-        if args:
-            kwargs.update(dict(zip(inspect.getargspec(forms.ModelForm.__init__)[0][1:], args)))
-        if 'instance' in kwargs and kwargs['instance']:
-            kwargs.setdefault('initial', {}).update({'login': getattr(kwargs['instance'].user, username_field)})
-        super(AdminPostForm, self).__init__(**kwargs)
-
-    def save(self, *args, **kwargs):
-        try:
-            self.user = User.objects.filter(**{username_field: self.cleaned_data['login']}).get()
-        except User.DoesNotExist:
-            if username_field != 'email':
-                create_data = {username_field: self.cleaned_data['login'],
-                               'email': '%s@example.com' % self.cleaned_data['login'],
-                               'is_staff': False}
-            else:
-                create_data = {'email': '%s@example.com' % self.cleaned_data['login'],
-                               'is_staff': False}
-            self.user = User.objects.create(**create_data)
-        return super(AdminPostForm, self).save(*args, **kwargs)
-
-
 try:
     class EditProfileForm(forms.ModelForm):
         class Meta(object):

--- a/pybb/tests.py
+++ b/pybb/tests.py
@@ -836,29 +836,6 @@ class FeaturesTest(TestCase, SharedTestModule):
         self.assertContains(response, 'test edit')
         self.assertIsNotNone(Post.objects.get(id=self.post.id).updated)
 
-        # Check admin form
-        self.user.is_staff = True
-        self.user.save()
-        response = self.client.get(edit_post_url)
-        self.assertEqual(response.status_code, 200)
-        tree = html.fromstring(response.content)
-        values = dict(tree.xpath('//form[@method="post"]')[0].form_values())
-        values['body'] = 'test edit'
-        values['login'] = 'new_login'
-        response = self.client.post(edit_post_url, data=values, follow=True)
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'test edit')
-
-    def test_admin_post_add(self):
-        self.user.is_staff = True
-        self.user.save()
-        self.login_client()
-        response = self.client.post(reverse('pybb:add_post', kwargs={'topic_id': self.topic.id}),
-                                    data={'quote_id': self.post.id, 'body': 'test admin post', 'user': 'zeus'},
-                                    follow=True)
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'test admin post')
-
     def test_stick(self):
         self.user.is_superuser = True
         self.user.save()

--- a/pybb/views.py
+++ b/pybb/views.py
@@ -21,10 +21,8 @@ from django.views.decorators.csrf import csrf_protect
 from django.views import generic
 from pybb import compat, defaults, util
 from pybb.compat import get_atomic_func
-from pybb.forms import PostForm, AdminPostForm, AttachmentFormSet, \
-    PollAnswerFormSet, PollForm, ForumSubscriptionForm, ModeratorForm
-from pybb.models import Category, Forum, ForumSubscription, Topic, Post, TopicReadTracker, \
-    ForumReadTracker, PollAnswerUser
+from pybb.forms import PostForm, AttachmentFormSet, PollAnswerFormSet, PollForm, ForumSubscriptionForm, ModeratorForm
+from pybb.models import Category, Forum, ForumSubscription, Topic, Post, TopicReadTracker, ForumReadTracker, PollAnswerUser
 from pybb.permissions import perms
 from pybb.templatetags.pybb_tags import pybb_topic_poll_not_voted
 
@@ -237,16 +235,12 @@ class LatestTopicsView(PaginatorMixin, generic.ListView):
 class PybbFormsMixin(object):
 
     post_form_class = PostForm
-    admin_post_form_class = AdminPostForm
     attachment_formset_class = AttachmentFormSet
     poll_form_class = PollForm
     poll_answer_formset_class = PollAnswerFormSet
 
     def get_post_form_class(self):
         return self.post_form_class
-
-    def get_admin_post_form_class(self):
-        return self.admin_post_form_class
 
     def get_attachment_formset_class(self):
         return self.attachment_formset_class
@@ -319,12 +313,7 @@ class TopicView(RedirectToLoginMixin, PaginatorMixin, PybbFormsMixin, generic.Li
         if self.request.user.is_authenticated():
             self.request.user.is_moderator = perms.may_moderate_topic(self.request.user, self.topic)
             self.request.user.is_subscribed = self.request.user in self.topic.subscribers.all()
-            if perms.may_post_as_admin(self.request.user):
-                ctx['form'] = self.get_admin_post_form_class()(
-                    initial={'login': getattr(self.request.user, username_field)},
-                    topic=self.topic)
-            else:
-                ctx['form'] = self.get_post_form_class()(topic=self.topic)
+            ctx['form'] = self.get_post_form_class()(topic=self.topic)
             self.mark_read(self.request.user, self.topic)
         elif defaults.PYBB_ENABLE_ANONYMOUS_POST:
             ctx['form'] = self.get_post_form_class()(topic=self.topic)
@@ -400,10 +389,7 @@ class PostEditMixin(PybbFormsMixin):
         return super(PostEditMixin, self).post(request, *args, **kwargs)
 
     def get_form_class(self):
-        if perms.may_post_as_admin(self.request.user):
-            return self.get_admin_post_form_class()
-        else:
-            return self.get_post_form_class()
+        return self.get_post_form_class()
 
     def get_context_data(self, **kwargs):
 
@@ -528,8 +514,6 @@ class AddPostView(PostEditMixin, generic.CreateView):
                            ip=ip, initial={}))
         if getattr(self, 'quote', None):
             form_kwargs['initial']['body'] = self.quote
-        if perms.may_post_as_admin(self.user):
-            form_kwargs['initial']['login'] = getattr(self.user, username_field)
         form_kwargs['may_create_poll'] = perms.may_create_poll(self.user)
         form_kwargs['may_edit_topic_slug'] = perms.may_edit_topic_slug(self.user)
         return form_kwargs
@@ -882,7 +866,6 @@ def block_user(request, username):
                 Forum.objects.get(id=f['topic__forum_id']).update_counters()
             except Forum.DoesNotExist:
                 pass
-
 
     msg = _('User successfuly blocked')
     messages.success(request, msg, fail_silently=True)


### PR DESCRIPTION
…automagically creating it if it did not exist.

Don't agree with the need for admins to have the ability to post as any username or create users on the fly.  It is confusing for end users that do not request it, and looks very much like a vulnerability.  Those that do need the functionality can use a 3rd party package such as django-hijack or subclass the view and write their own `get_post_form_class` implementation.