### PR TITLE
Use Python stdlib version of importlib instead of deprecated django.utils.importlib

### DIFF
--- a/pybb/util.py
+++ b/pybb/util.py
@@ -5,7 +5,7 @@ import os
 import warnings
 import uuid
 
-from django.utils.importlib import import_module
+from importlib import import_module
 from django.utils.six import string_types
 from django.utils.translation import ugettext as _
 from pybb import compat


### PR DESCRIPTION
django.utils.importlib was deprecated in Django 1.7 and removed in 1.9.

This PR updates the import as per Django's recommendation: https://docs.djangoproject.com/en/1.8/releases/1.7/#django-utils-dictconfig-django-utils-importlib