### PR TITLE
Use django.forms.utils for Django 1.9 compatibility.

### DIFF
--- a/pybb/views.py
+++ b/pybb/views.py
@@ -9,7 +9,7 @@ from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.urlresolvers import reverse
 from django.contrib import messages
 from django.db.models import F, Q
-from django.forms.util import ErrorList
+from django.forms.utils import ErrorList
 from django.http import HttpResponseRedirect, HttpResponse, Http404, HttpResponseBadRequest,\
     HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render


### PR DESCRIPTION
This change is needed for PyBBM to work on Django 1.9. 

django.forms.utils is removed in Django 1.9. Details: https://docs.djangoproject.com/en/1.9/releases/1.9/