### PR TITLE
Fix incorrect permissions check in UserTopics view

### DIFF
--- a/pybb/views.py
+++ b/pybb/views.py
@@ -546,7 +546,7 @@ class UserTopics(PaginatorMixin, generic.ListView):
     def get_queryset(self):
         qs = super(UserTopics, self).get_queryset()
         qs = qs.filter(user=self.user)
-        qs = perms.filter_topics(self.user, qs)
+        qs = perms.filter_topics(self.request.user, qs)
         qs = qs.order_by('-updated', '-created', '-id')
         return qs
 


### PR DESCRIPTION
By requesting a list of an admin users topics, unauthenticated users can see a list of hidden topics.