### PR TITLE
fix IP detection when using standardised proxy

### DIFF
--- a/pybb/util.py
+++ b/pybb/util.py
@@ -161,6 +161,17 @@ def build_cache_key(key_name, **kwargs):
         raise ValueError('Wrong key_name parameter passed: %s' % key_name)
 
 
+def get_ip(request, default=None):
+    """Returns the IP of the request, accounting for the possibility of being behind a proxy."""
+    ip = request.META.get("HTTP_X_FORWARDED_FOR", None)
+    if ip:
+        # X_FORWARDED_FOR returns client1, proxy1, proxy2,...
+        ip = ip.split(", ")[0]
+    else:
+        ip = request.META.get("REMOTE_ADDR", None)
+    return default if not ip else ip
+
+
 class FilePathGenerator(object):
     """
     Special class for generating random filenames

--- a/pybb/views.py
+++ b/pybb/views.py
@@ -446,7 +446,7 @@ class AddPostView(PostEditMixin, generic.CreateView):
         return super(AddPostView, self).dispatch(request, *args, **kwargs)
 
     def get_form_kwargs(self):
-        ip = self.request.META.get('REMOTE_ADDR', '')
+        ip = util.get_ip(self.request)
         form_kwargs = super(AddPostView, self).get_form_kwargs()
         form_kwargs.update(dict(topic=self.topic, forum=self.forum, user=self.user,
                            ip=ip, initial={}))


### PR DESCRIPTION
If used proxy doesn't use standard code (HTTP_X_FORWARDED_FOR), the "problem" is still there but I think this is enough. Else, we could use [django-ipware](https://github.com/un33k/django-ipware/) for exemple.