### PR TITLE
Templates should use staticfiles, not STATIC_URL

### DIFF
--- a/pybb/templates/pybb/_markitup.html
+++ b/pybb/templates/pybb/_markitup.html
@@ -7,11 +7,15 @@ This template will not exist anymore in the next release. Please do not use it.
 See docs about PYBB_MARKUP_ENGINES_PATHS setting and pybb.markup.bbcode.py
 {% endcomment %}
 
-<script type="text/javascript" src="{{ STATIC_URL }}markitup/ajax_csrf.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}markitup/jquery.markitup.js"></script>
-<link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}markitup/skins/simple/style.css">
-<link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}markitup/sets/{{ PYBB_MARKUP }}/style.css">
-<script type="text/javascript" src="{{ STATIC_URL }}markitup/sets/{{ PYBB_MARKUP }}/set.js"></script>
+<script type="text/javascript" src="{% static 'markitup/ajax_csrf.js' %}"></script>
+<script type="text/javascript" src="{% static 'markitup/jquery.markitup.js' %}"></script>
+<link rel="stylesheet" type="text/css" href="{% static 'markitup/skins/simple/style.css' %}">
+{% with 'markitup/sets/'|add:PYBB_MARKUP|add:'/style.css' as style_static %}
+<link rel="stylesheet" type="text/css" href="{% static style_static %}">
+{% endwith %}
+{% with 'markitup/sets/'|add:PYBB_MARKUP|add:'/set.js' as static_setjs %}
+<script type="text/javascript" src="{% static static_setjs %}"></script>
+{% endwith %}
 
 <script type="text/javascript">
 $(function() {

--- a/pybb/templates/pybb/add_post.html
+++ b/pybb/templates/pybb/add_post.html
@@ -1,5 +1,5 @@
 {% extends 'pybb/base.html' %}
-{% load i18n pybb_tags %}
+{% load i18n pybb_tags staticfiles %}
 
 {% block title %}
 {% if forum %}{% trans "New topic" %}{% else %}{% trans "New reply" %}{% endif %}
@@ -12,7 +12,7 @@
 {% block extra_script %}
     {{ block.super }}
     {{ form.media.js }}
-    <script type="text/javascript" src="{{ STATIC_URL }}pybb/js/jquery.formset.min.js"></script>
+    <script type="text/javascript" src="{% static 'pybb/js/jquery.formset.min.js' %}"></script>
 {% endblock %}
 
 {% block breadcrumb %}

--- a/pybb/templates/pybb/edit_post.html
+++ b/pybb/templates/pybb/edit_post.html
@@ -1,5 +1,5 @@
 {% extends 'pybb/base.html' %}
-{% load pybb_tags i18n %}
+{% load pybb_tags i18n staticfiles %}
 
 {% block title %}{% trans "Editing the post" %}{% endblock title %}
 
@@ -10,7 +10,7 @@
 {% block extra_script %}
     {{ block.super }}
     {{ form.media.js }}
-    <script type="text/javascript" src="{{ STATIC_URL }}pybb/js/jquery.formset.min.js"></script>
+    <script type="text/javascript" src="{% static 'pybb/js/jquery.formset.min.js' %}"></script>
 {% endblock %}
 
 {% block content %}

--- a/pybb/templates/pybb/post_form.html
+++ b/pybb/templates/pybb/post_form.html
@@ -1,5 +1,5 @@
 {% load url from future %}
-{% load i18n pybb_tags %}
+{% load i18n pybb_tags staticfiles %}
 <form class="post-form" action="
     {% if forum %}
         {% url 'pybb:add_topic' forum.pk %}
@@ -18,9 +18,11 @@
     {% if form.login %} {% include "pybb/form_field.html" with field=form.login %}  {% endif %}
     {% if form.body %} {% include "pybb/form_field.html" with field=form.body %}  {% endif %}
     <div id='emoticons'>
-      {% for smile, url in form.available_smiles.items %}
-        <a href='#' title='{{ smile|safe }}'><img src='{{ STATIC_URL }}{{ form.smiles_prefix }}{{ url }}'></a>
-      {% endfor %}
+    {% for smile, url in form.available_smiles.items %}
+        {% with form.smiles_prefix|add:url as static_smiley %}
+            <a href='#' title='{{ smile|safe }}'><img src='{% static static_smiley %}'></a>
+        {% endwith %}
+    {% endfor %}
     </div>
 
     {% if request.user|pybb_may_create_poll and form.poll_type %}

--- a/pybb/templates/pybb/post_template.html
+++ b/pybb/templates/pybb/post_template.html
@@ -1,5 +1,5 @@
 {% load url from future %}
-{% load i18n pybb_tags %}
+{% load i18n pybb_tags staticfiles %}
 
 {% pybb_get_profile user=post.user as post_user_profile %}
 {% pybb_get_profile user=user as user_profile %}
@@ -85,7 +85,7 @@
                 {% endif %}
                 <div class='attachments'>
                     {% for attachment in post.attachments.all %}
-                        <a href="{{ attachment.file.url }}"><img src="{{ STATIC_URL }}pybb/img/attachment.png"> {{ attachment.size_display }}</a>
+                        <a href="{{ attachment.file.url }}"><img src="{% static 'pybb/img/attachment.png' %}"> {{ attachment.size_display }}</a>
                     {% endfor %}
                 </div>
             </div>

--- a/pybb/templates/pybb/topic.html
+++ b/pybb/templates/pybb/topic.html
@@ -2,7 +2,7 @@
 
 {% load url from future %}
 
-{% load pybb_tags i18n %}
+{% load pybb_tags i18n staticfiles %}
 
 {% block title %}{{ topic }}{% endblock %}
 
@@ -13,7 +13,7 @@
 {% block extra_script %}
     {{ block.super }}
     {{ form.media.js }}
-    <script type="text/javascript" src="{{ STATIC_URL }}pybb/js/jquery.formset.min.js"></script>
+    <script type="text/javascript" src="{% static 'pybb/js/jquery.formset.min.js' %}"></script>
 {% endblock %}
 
 {% block breadcrumb %}

--- a/test/test_project/test_project/settings.py
+++ b/test/test_project/test_project/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.sites',
+    'django.contrib.staticfiles',
     'test_app',
 ]
 if django.VERSION[:2] < (1, 7) and south_installed:
@@ -60,7 +61,6 @@ TEMPLATE_CONTEXT_PROCESSORS = [
     'django.core.context_processors.debug',
     'django.core.context_processors.i18n',
     'django.core.context_processors.media',
-    'django.core.context_processors.static',
     'django.core.context_processors.request',
     'pybb.context_processors.processor',
     'django.core.context_processors.tz'


### PR DESCRIPTION
As far as I can tell, it's generally preferred to use staticfiles and
{%static 'relative-filepath' %} instead of using STATIC_URL.

In my Django 1.8 project, I didn't get the static context handler by default.
This resulted in a good bit of digging around before I found out what was
causing STATIC_URL to be undefined.

The Django documentation on static file handling in templates doesn't
even mention using STATIC_URL anymore - it looks like Django 1.4 was the
last version that had documentation showing this usage:
https://docs.djangoproject.com/en/1.4/howto/static-files/

I've also gone ahead and removed context_processors.static and added
django.contrib.staticfiles to the installed apps in the project settings.py.