### PR TITLE
may_subscribe_topic is passed topics, not forums.

### DIFF
--- a/pybb/permissions.py
+++ b/pybb/permissions.py
@@ -115,7 +115,7 @@ class DefaultPermissionHandler(object):
         """ return True if `user` may post as admin """
         return user.is_staff
 
-    def may_subscribe_topic(self, user, forum):
+    def may_subscribe_topic(self, user, topic):
         """ return True if `user` is allowed to subscribe to a `topic` """
         return not defaults.PYBB_DISABLE_SUBSCRIPTIONS
 


### PR DESCRIPTION
It's definition in permissions.py is wrong, as it accepts a topic (and is
passed them in views.py) but stores them in "forum". This changes the
parameter name from "forum" to "topic".