### PR TITLE
Separated hyperlinks that had no space between them in index template.

### DIFF
--- a/pybb/templates/pybb/index.html
+++ b/pybb/templates/pybb/index.html
@@ -21,12 +21,8 @@
     {% endif %}
     {% if user.is_authenticated %}
         <div id='mark-all-as-read'>
-            <a href='{% url 'pybb:topic_latest' %}'>
-                {% trans "Last updates in topics" %}
-            </a>
-            <a href='{% url 'pybb:mark_all_as_read' %}'>
-                {% trans "Mark all forums as read" %}
-            </a>
+            <a href='{% url 'pybb:topic_latest' %}'>{% trans "Last updates in topics" %}</a> /
+            <a href='{% url 'pybb:mark_all_as_read' %}'>{% trans "Mark all forums as read" %}</a>
         </div>
     {% endif %}
 {% endblock content %}


### PR DESCRIPTION
Hyperlinks "Last updates in topics" and "Mark all forums as read" were displayed next to each other without any space between them (the space was a part of the first hyperlink) making it hard to distinguish one from another.


Screenshot:
<img width="311" alt="screen shot 2016-02-07 at 10 17 11 am" src="https://cloud.githubusercontent.com/assets/4534782/12871627/1a8733d8-cd84-11e5-8b49-6ead18a876a0.png">

After this change, the space is no longer a part of the hyperlink and a slash has been inserted between the hyperlinks (for consistency with topic.html: Stick topic / Close topic / Admin / Subscribe).