### PR TITLE
Allow to use pybbm without Pillow and fixes ManyToManyField warning

### DIFF
--- a/pybb/compat.py
+++ b/pybb/compat.py
@@ -8,6 +8,11 @@ from unidecode import unidecode
 
 def get_image_field_class():
     try:
+        from PIL import Image
+    except ImportError:
+        from django.db.models import FileField
+        return FileField
+    try:
         from sorl.thumbnail import ImageField
     except ImportError:
         from django.db.models import ImageField
@@ -15,6 +20,10 @@ def get_image_field_class():
 
 
 def get_image_field_full_name():
+    try:
+        from PIL import Image
+    except ImportError:
+        return 'django.db.models.fields.files.FileField'
     try:
         from sorl.thumbnail import ImageField
         name = 'sorl.thumbnail.fields.ImageField'

--- a/pybb/migrations/0005_auto_20151108_1528.py
+++ b/pybb/migrations/0005_auto_20151108_1528.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 import pybb.util
+from pybb.compat import get_image_field_class
 
 
 class Migration(migrations.Migration):
@@ -21,7 +22,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='profile',
             name='avatar',
-            field=models.ImageField(blank=True, null=True, upload_to=pybb.util.FilePathGenerator(to='pybb/avatar'), verbose_name='Avatar'),
+            field=get_image_field_class()(blank=True, null=True, upload_to=pybb.util.FilePathGenerator(to='pybb/avatar'), verbose_name='Avatar'),
         ),
         migrations.AlterField(
             model_name='profile',

--- a/pybb/models.py
+++ b/pybb/models.py
@@ -67,7 +67,7 @@ class Forum(models.Model):
     name = models.CharField(_('Name'), max_length=80)
     position = models.IntegerField(_('Position'), blank=True, default=0)
     description = models.TextField(_('Description'), blank=True)
-    moderators = models.ManyToManyField(get_user_model_path(), blank=True, null=True, verbose_name=_('Moderators'))
+    moderators = models.ManyToManyField(get_user_model_path(), blank=True, verbose_name=_('Moderators'))
     updated = models.DateTimeField(_('Updated'), blank=True, null=True)
     post_count = models.IntegerField(_('Post count'), blank=True, default=0)
     topic_count = models.IntegerField(_('Topic count'), blank=True, default=0)


### PR DESCRIPTION
Not every Django project environment has Pillow installed and some forum installations may not use avatars at all.

Also fixed 'null has no effect on ManyToManyField' error when pybb.models.Forum.moderators field is initialized.