### PR TITLE
Allow ALL tests to be runned with all DB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ env:
   - DJANGO="Django>=1.10,<1.11" DB=postgres
   - DJANGO="Django>=1.10,<1.11" DB=mysql
 before_script:
-  - mysql -e 'create database pybbm;'
-  - psql -c 'create database pybbm;' -U postgres
+  - if [[ $DB == mysql ]]; then mysql -e 'SET GLOBAL wait_timeout = 36000 ; create database pybbm;'; fi
+  - if [[ $DB == postgres ]]; then psql -c 'create database pybbm;' -U postgres; fi
 install:
   - if [[ $DB == mysql ]]; then pip install -qU mysqlclient; fi
   - if [[ $DB == postgres ]]; then pip install -qU psycopg2; fi

--- a/docs/problems.rst
+++ b/docs/problems.rst
@@ -1,0 +1,9 @@
+Known problems
+==============
+
+Using with a database that doest not support microseconds
+---------------------------------------------------------
+
+If you are using a database which does not support microseconds (MySQL for eg.), a forum can be
+wrongly marked read. It can happens if a user who read the only unread topic from a forum in
+the same time an other user create / update an other topic on the same forum.

--- a/test/test_project/test_project/settings.py
+++ b/test/test_project/test_project/settings.py
@@ -18,13 +18,13 @@ if test_db == 'mysql':
     DATABASES['default'].update({
         'ENGINE': 'django.db.backends.mysql',
         'NAME': 'pybbm',
-        'USER': 'root',
+        # 'USER': 'root',
         'TEST_COLLATION': 'utf8_general_ci',
     })
 elif test_db == 'postgres':
     DATABASES['default'].update({
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'USER': 'postgres',
+        # 'USER': 'postgres',
         'NAME': 'pybbm',
         'OPTIONS': {}
     })

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,19 @@
 [tox]
-envlist = py{27,34,35}-django1{8,9,10}
+envlist = py{27,34,35}-django1{8,9,10}-{sqlite,postgres,mysql}
 
 [testenv]
+setenv=
+    mysql: DB=mysql
+    postgres: DB=postgres
+
 commands = {envpython} setup.py test
 basepython =
     py27: python2.7
     py34: python3.4
     py35: python3.5
 deps =
+    mysql: mysqlclient
+    postgres: psycopg2
     -Urtest/test_project/requirements_test.txt
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10


### PR DESCRIPTION
With a DB (like MySQL) which does not support microseconds, we force
a 1 second sleep for some operations to avoid failures for some tests which
require a different datetime between two operations.  
It adds few seconds to run the test suite with mysql but it run all
tests (there were some tests which were skipped for mysql)

This commit allow to run test with sqlite, mysql or postgres
with tox for local testing.

Also fix travis issues:

* mysql has gone away
* only create DBs if required

Add methods `create_post` and `create_post_via_http` in `tests.py` to simplify tests creation.

Add a "problems" section in the doc about using DBs without microseconds
support to explain what are the side-effects.