### PR TITLE
add missing indexes

### DIFF
--- a/pybb/migrations/0007_auto_20170111_1504.py
+++ b/pybb/migrations/0007_auto_20170111_1504.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pybb', '0006_forum_subscriptions'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='post',
+            name='updated',
+            field=models.DateTimeField(db_index=True, null=True, verbose_name='Updated', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='topic',
+            name='created',
+            field=models.DateTimeField(null=True, verbose_name='Created', db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='topic',
+            name='updated',
+            field=models.DateTimeField(null=True, verbose_name='Updated', db_index=True),
+        ),
+    ]

--- a/pybb/models.py
+++ b/pybb/models.py
@@ -181,8 +181,8 @@ class Topic(models.Model):
 
     forum = models.ForeignKey(Forum, related_name='topics', verbose_name=_('Forum'))
     name = models.CharField(_('Subject'), max_length=255)
-    created = models.DateTimeField(_('Created'), null=True)
-    updated = models.DateTimeField(_('Updated'), null=True)
+    created = models.DateTimeField(_('Created'), null=True, db_index=True)
+    updated = models.DateTimeField(_('Updated'), null=True, db_index=True)
     user = models.ForeignKey(get_user_model_path(), verbose_name=_('User'))
     views = models.IntegerField(_('Views count'), blank=True, default=0)
     sticky = models.BooleanField(_('Sticky'), blank=True, default=False)
@@ -294,7 +294,7 @@ class Post(RenderableItem):
     topic = models.ForeignKey(Topic, related_name='posts', verbose_name=_('Topic'))
     user = models.ForeignKey(get_user_model_path(), related_name='posts', verbose_name=_('User'))
     created = models.DateTimeField(_('Created'), blank=True, db_index=True)
-    updated = models.DateTimeField(_('Updated'), blank=True, null=True)
+    updated = models.DateTimeField(_('Updated'), blank=True, null=True, db_index=True)
     user_ip = models.GenericIPAddressField(_('User IP'), blank=True, null=True, default='0.0.0.0')
     on_moderation = models.BooleanField(_('On moderation'), default=False)
 


### PR DESCRIPTION
* `topic.updated` is used when using "first-unread" and should be used when creating a "last activity" topic for a website. DB index has been added.
* `topic.created` is used as the default sort order of topic via Meta.ordering. DB index has been added.
* `post.updated` should be used when using a search index app (django-haystack for exemple) to reindex only the updated topics. DB index has been added.