### PR TITLE
fix mysql test error because of PR merges

### DIFF
--- a/docs/problems.rst
+++ b/docs/problems.rst
@@ -4,6 +4,6 @@ Known problems
 Using with a database that doest not support microseconds
 ---------------------------------------------------------
 
-If you are using a database which does not support microseconds (MySQL for eg.), a forum can be
-wrongly marked read. It can happens if a user who read the only unread topic from a forum in
-the same time an other user create / update an other topic on the same forum.
+If you are using a database which does not support microseconds (MySQL before v5.7 for eg.), a
+forum can be wrongly marked read. It can happens if a user who read the only unread topic from
+a forum in the same time an other user create / update an other topic on the same forum.

--- a/pybb/tests.py
+++ b/pybb/tests.py
@@ -265,7 +265,7 @@ class FeaturesTest(TestCase, SharedTestModule):
     def test_read_tracking(self):
         topic = Topic(name='xtopic', forum=self.forum, user=self.user)
         topic.save()
-        post = self.create_post(topic=topic, user=self.user, body='one')
+        post = self.create_post(topic=topic, user=self.user, body='one', _sleep=True)
         client = Client()
         client.login(username='zeus', password='zeus')
         # Topic status
@@ -288,7 +288,7 @@ class FeaturesTest(TestCase, SharedTestModule):
         self.assertFalse(
             tree.xpath('//a[@href="%s"]/parent::td[contains(@class,"unread")]' % topic.forum.get_absolute_url()))
         # Post message
-        response = self.create_post_via_http(client, topic_id=topic.id, body='test tracking')
+        response = self.create_post_via_http(client, topic_id=topic.id, body='test tracking', _sleep=True)
         self.assertContains(response, 'test tracking')
         # Topic status - readed
         tree = html.fromstring(client.get(topic.forum.get_absolute_url()).content)


### PR DESCRIPTION
There was a merged PR (#197) with some read-tracking modifications which needed a little adjustment to work with another merged PR (#258)

This PR fixes this conflict.