### PR TITLE
Move topic and split posts

### DIFF
--- a/pybb/models.py
+++ b/pybb/models.py
@@ -311,6 +311,10 @@ class Post(RenderableItem):
     def __str__(self):
         return self.summary()
 
+    @cached_property
+    def is_topic_head(self):
+        return self.pk and self.topic.head.pk == self.pk
+
     def save(self, *args, **kwargs):
         created_at = tznow()
         if self.created is None:

--- a/pybb/templates/pybb/move_post.html
+++ b/pybb/templates/pybb/move_post.html
@@ -2,7 +2,7 @@
 {% load i18n pybb_tags %}
 
 {% block content %}
-    
+
     {% if post.is_topic_head %}
         <h1>{% blocktrans with topic=post.topic %}Move topic "{{ topic }}"{% endblocktrans %}</h1>
     {% else %}
@@ -14,9 +14,9 @@
             {% if not post.is_topic_head %}
             {% pybb_get_profile post.user as author %}
             <div>
-                <label>{% blocktrans %}Starting post by {{ author }}{% endblocktrans %}</label>
+                <label>{% blocktrans with author.get_display_name as author_name %}Starting post by {{ author_name }}{% endblocktrans %}</label>
                 <div class="post-preview well form-control">
-                    <blockquote>{{ post.body_html|safe|truncatewords_html:20 }}</blockquote>
+                    {{ post.body_html|safe|truncatewords_html:20 }}
                 </div>
             </div>
             {% endif %}

--- a/pybb/templates/pybb/move_post.html
+++ b/pybb/templates/pybb/move_post.html
@@ -1,0 +1,35 @@
+{% extends 'pybb/base.html' %}
+{% load i18n pybb_tags %}
+
+{% block content %}
+    
+    {% if post.is_topic_head %}
+        <h1>{% blocktrans with topic=post.topic %}Move topic "{{ topic }}"{% endblocktrans %}</h1>
+    {% else %}
+        <h1>{% blocktrans with topic=post.topic %}Split posts from topic "{{ topic }}"{% endblocktrans %}</h1>
+    {% endif %}
+    <form method="post" action="." class="move-post-form">
+        {% csrf_token %}
+        <fieldset>
+            {% if not post.is_topic_head %}
+            {% pybb_get_profile post.user as author %}
+            <div>
+                <label>{% blocktrans %}Starting post by {{ author }}{% endblocktrans %}</label>
+                <div class="post-preview well form-control">
+                    <blockquote>{{ post.body_html|safe|truncatewords_html:20 }}</blockquote>
+                </div>
+            </div>
+            {% endif %}
+            {% include "pybb/form_errors.html" %}
+            {% if form.move_to %} {% include "pybb/form_field.html" with field=form.move_to %} {% endif %}
+            {% if form.number %} {% include "pybb/form_field.html" with field=form.number %} {% endif %}
+            {% if form.name %} {% include "pybb/form_field.html" with field=form.name %} {% endif %}
+            {% if form.slug %} {% include "pybb/form_field.html" with field=form.slug %} {% endif %}
+        </fieldset>
+
+        <p class="submit">
+            <a class="btn" href="{{ post.get_absolute_url }}">{% trans 'Cancel' %}</a>
+            <input type="submit" class="btn btn-danger" value="{% if post.is_topic_head %}{% trans 'Move this topic' %}{% else %}{% trans "Split posts" %}{% endif %}" />
+        </p>
+    </form>
+{% endblock content %}

--- a/pybb/templates/pybb/post_template.html
+++ b/pybb/templates/pybb/post_template.html
@@ -48,7 +48,9 @@
                 {% if post.on_moderation and user.is_moderator %}
                     <a href="{% url 'pybb:moderate_post' pk=post.id %}">{% trans 'Approve post' %}</a>
                 {% endif %}
-
+                {% if user.is_moderator %}
+                    <a href="{% url 'pybb:move_post' pk=post.id %}">{% if post.is_topic_head %}{% trans 'Move' %}{% else %}{% trans "Split" %}{% endif %}</a>
+                {% endif %}
                 {% if perms.pybb.change_post and user.is_staff %}
                     <a href="{% url 'admin:pybb_post_change' post.id %}">{% trans 'Admin' %}</a>
                 {% endif %}

--- a/pybb/templatetags/pybb_tags.py
+++ b/pybb/templatetags/pybb_tags.py
@@ -238,8 +238,8 @@ def pybb_get_latest_posts(context, cnt=5, user=None):
 
 def load_perms_filters():
     def partial(func_name, perms_obj):
-        def newfunc(user, obj):
-            return getattr(perms_obj, func_name)(user, obj)
+        def newfunc(user, obj_or_qs):
+            return getattr(perms_obj, func_name)(user, obj_or_qs)
         return newfunc
 
     def partial_no_param(func_name, perms_obj):
@@ -247,13 +247,21 @@ def load_perms_filters():
             return getattr(perms_obj, func_name)(user)
         return newfunc
 
-    for method in inspect.getmembers(perms):
-        if inspect.ismethod(method[1]) and inspect.getargspec(method[1]).args[0] == 'self' and\
-                (method[0].startswith('may') or method[0].startswith('filter')):
-            if len(inspect.getargspec(method[1]).args) == 3:
-                register.filter('%s%s' % ('pybb_', method[0]), partial(method[0], perms))
-            elif len(inspect.getargspec(method[1]).args) == 2: # only user should be passed to permission method
-                register.filter('%s%s' % ('pybb_', method[0]), partial_no_param(method[0], perms))
+    for method_name, method in inspect.getmembers(perms):
+        if not inspect.ismethod(method):
+            continue  # only methods are used to dynamically build templatetags
+        if not method_name.startswith('may') and not method_name.startswith('filter'):
+            continue  # only (may|filter)* methods are used to dynamically build templatetags
+        method_args = inspect.getargspec(method).args
+        args_count = len(method_args)
+        if args_count not in (2, 3):
+            continue  # only methods with 2 or 3 params
+        if method_args[0] != 'self' or method_args[1] != 'user':
+            continue  # only methods with self and user as first args
+        if len(inspect.getargspec(method).args) == 3:
+            register.filter('%s%s' % ('pybb_', method_name), partial(method_name, perms))
+        elif len(inspect.getargspec(method).args) == 2:
+            register.filter('%s%s' % ('pybb_', method_name), partial_no_param(method_name, perms))
 load_perms_filters()
 
 

--- a/pybb/templatetags/pybb_tags.py
+++ b/pybb/templatetags/pybb_tags.py
@@ -64,12 +64,12 @@ def pybb_user_time(context_time, user):
             minutes = int(delta.seconds / 60)
             msg = ungettext('%d minute ago', '%d minutes ago', minutes)
             return msg % minutes
-    if context['user'].is_authenticated():
+    if user.is_authenticated():
         if time.daylight:
             tz1 = time.altzone
         else:
             tz1 = time.timezone
-        tz = tz1 + util.get_pybb_profile(context['user']).time_zone * 60 * 60
+        tz = tz1 + util.get_pybb_profile(user).time_zone * 60 * 60
         context_time = context_time + timedelta(seconds=tz)
     if today < context_time < tomorrow:
         return _('today, %s') % context_time.strftime('%H:%M')

--- a/pybb/templatetags/pybb_tags.py
+++ b/pybb/templatetags/pybb_tags.py
@@ -215,7 +215,7 @@ def pybb_get_profile(*args, **kwargs):
     try:
         return util.get_pybb_profile(kwargs.get('user') or args[0])
     except:
-        return util.get_pybb_profile_model().objects.none()
+        return None
 
 
 @register.assignment_tag(takes_context=True)

--- a/pybb/templatetags/pybb_tags.py
+++ b/pybb/templatetags/pybb_tags.py
@@ -29,7 +29,7 @@ register = template.Library()
 def pybb_time(parser, token):
     try:
         tag, context_time = token.split_contents()
-    except ValueError:
+    except ValueError: # pragma: no cover
         raise template.TemplateSyntaxError('pybb_time requires single argument')
     else:
         return PybbTimeNode(context_time)
@@ -65,9 +65,9 @@ def pybb_user_time(context_time, user):
             msg = ungettext('%d minute ago', '%d minutes ago', minutes)
             return msg % minutes
     if user.is_authenticated():
-        if time.daylight:
+        if time.daylight: # pragma: no cover
             tz1 = time.altzone
-        else:
+        else: # pragma: no cover
             tz1 = time.timezone
         tz = tz1 + util.get_pybb_profile(user).time_zone * 60 * 60
         context_time = context_time + timedelta(seconds=tz)
@@ -249,15 +249,15 @@ def load_perms_filters():
 
     for method_name, method in inspect.getmembers(perms):
         if not inspect.ismethod(method):
-            continue  # only methods are used to dynamically build templatetags
+            continue  # pragma: no cover - only methods are used to dynamically build templatetags
         if not method_name.startswith('may') and not method_name.startswith('filter'):
-            continue  # only (may|filter)* methods are used to dynamically build templatetags
+            continue  # pragma: no cover - only (may|filter)* methods are used to dynamically build templatetags
         method_args = inspect.getargspec(method).args
         args_count = len(method_args)
         if args_count not in (2, 3):
-            continue  # only methods with 2 or 3 params
+            continue  # pragma: no cover - only methods with 2 or 3 params
         if method_args[0] != 'self' or method_args[1] != 'user':
-            continue  # only methods with self and user as first args
+            continue  # pragma: no cover - only methods with self and user as first args
         if len(inspect.getargspec(method).args) == 3:
             register.filter('%s%s' % ('pybb_', method_name), partial(method_name, perms))
         elif len(inspect.getargspec(method).args) == 2:

--- a/pybb/templatetags/pybb_tags.py
+++ b/pybb/templatetags/pybb_tags.py
@@ -200,6 +200,8 @@ def pybb_topic_inline_pagination(topic):
 
 @register.filter
 def pybb_topic_poll_not_voted(topic, user):
+    if user.is_anonymous():
+        return True
     return not PollAnswerUser.objects.filter(poll_answer__topic=topic, user=user).exists()
 
 

--- a/pybb/tests.py
+++ b/pybb/tests.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-import datetime
+import datetime, time
+import inspect
+import math
 import os
-from django.contrib.auth.models import Permission
+from django.contrib.auth.models import AnonymousUser, Permission
 from django.conf import settings
 from django.core import mail
 from django.core.cache import cache
@@ -11,11 +13,13 @@ from django.core.urlresolvers import reverse
 from django.core.exceptions import ValidationError
 from django.db import connection
 from django.db.models import Q
+from django.template import Context, Template
 from django.test import TestCase
 from django.test.client import Client
 from django.test.utils import override_settings
-from django.utils import timezone
+from django.utils import dateformat, timezone
 from django.utils.translation.trans_real import get_supported_language_variant
+
 
 from pybb import permissions, views as pybb_views
 from pybb.templatetags.pybb_tags import pybb_is_topic_unread, pybb_topic_unread, pybb_forum_unread, \
@@ -32,8 +36,8 @@ except ImportError:  # pragma: no cover
     raise Exception('PyBB requires lxml for self testing')
 
 from pybb import defaults
-from pybb.models import Category, Forum, Topic, Post, PollAnswer, TopicReadTracker, \
-    ForumReadTracker, ForumSubscription
+from pybb.models import Category, Forum, Topic, Post, PollAnswer, PollAnswerUser, \
+    TopicReadTracker, ForumReadTracker, ForumSubscription
 
 if getattr(connection.features, 'supports_microsecond_precision', False):
     def sleep_only_if_required(s):
@@ -2429,3 +2433,514 @@ class NiceUrlsTest(TestCase, SharedTestModule):
 
     def tearDown(self):
         defaults.PYBB_NICE_URL = self.ORIGINAL_PYBB_NICE_URL
+
+
+class TestTemplateTags(TestCase, SharedTestModule):
+    """Tests all templatetags and filter defined by pybb"""
+
+    # def setUp(self):
+        # self.create_user()
+        # self.create_initial()
+    
+    def test_pybb_time_anonymous(self):
+        template = Template('{% load pybb_tags %}{% pybb_time a_time %}')
+        context = Context({'user': AnonymousUser()})
+
+        context['a_time'] = timezone.now() - timezone.timedelta(days=2)
+        output = template.render(context)
+        self.assertEqual(output, dateformat.format(context['a_time'], 'd M, Y H:i'))
+        
+        context['a_time'] = timezone.now() - timezone.timedelta(days=1)
+        output = template.render(context)
+        self.assertEqual(output, 'yesterday, %s' % context['a_time'].strftime('%H:%M'))
+        
+        context['a_time'] = timezone.now() - timezone.timedelta(hours=1)
+        output = template.render(context)
+        self.assertEqual(output, 'today, %s' % context['a_time'].strftime('%H:%M'))
+        
+        context['a_time'] = timezone.now() - timezone.timedelta(minutes=30)
+        output = template.render(context)
+        self.assertEqual(output, '30 minutes ago')
+        
+        context['a_time'] = timezone.now() - timezone.timedelta(seconds=30)
+        output = template.render(context)
+        self.assertEqual(output, '30 seconds ago')
+
+    def test_pybb_time_authenticated(self):
+        self.create_user()
+        template = Template('{% load pybb_tags %}{% pybb_time a_time %}')
+        context = Context({'user': self.user})
+        context['a_time'] = timezone.now() - timezone.timedelta(days=2)
+        output = template.render(context)
+        tz = util.get_pybb_profile(self.user).time_zone * 60 * 60
+        tz += time.altzone if time.daylight else time.timezone
+        user_datetime = context['a_time'] + timezone.timedelta(seconds=tz)
+        self.assertEqual(output, dateformat.format(user_datetime, 'd M, Y H:i'))
+        
+        context['a_time'] = timezone.now() - timezone.timedelta(seconds=30)
+        output = template.render(context)
+        self.assertEqual(output, '30 seconds ago')
+
+    def test_pybb_get_time(self):
+        template = Template(('{% load pybb_tags %}{% pybb_get_time a_time as time_output %}'
+                             '{{ time_output|upper }}'))
+        context = Context({'user': AnonymousUser(),
+                           'a_time': timezone.now() - timezone.timedelta(seconds=30)})
+        output = template.render(context)
+        self.assertEqual(output, '30 SECONDS AGO')
+    
+    def test_pybb_link(self):
+        self.create_user()
+        self.create_initial()
+        template = Template(('{% load pybb_tags %}'
+                             '{% pybb_link topic %}, '
+                             '{% pybb_link forum %}, '
+                             '{% pybb_link post "Hello <World>" %}'))
+        context = Context({'user': AnonymousUser(),
+                           'post': self.post,
+                           'topic': self.topic,
+                           'forum': self.forum})
+        expected = ('<a href="%s">%s</a>' % (self.topic.get_absolute_url(), self.topic),
+                    '<a href="%s">%s</a>' % (self.forum.get_absolute_url(), self.forum),
+                    '<a href="%s">%s</a>' % (self.post.get_absolute_url(), 'Hello &lt;World&gt;'))
+        expected = ', '.join(expected)
+        output = template.render(context)
+        self.assertEqual(output, expected)
+
+    def test_pybb_posted_by(self):
+        self.create_user()
+        self.create_initial()
+        template = Template(('{% load pybb_tags %}'
+                             '{% if post|pybb_posted_by:user %}YES{% else %}NO{% endif %}:'
+                             '{% if post|pybb_posted_by:anonymous %}YES{% else %}NO{% endif %}'))
+        context = Context({'user': self.user,
+                           'anonymous': AnonymousUser(),
+                           'post': self.post})
+        output = template.render(context)
+        self.assertEqual(output, 'YES:NO')
+
+    
+    def test_pybb_is_topic_unread(self):
+        self.create_user()
+        self.create_initial()
+        self.login_client()
+        self.client.get(self.topic.get_absolute_url())
+        template = Template(('{% load pybb_tags %}'
+                             '{% if topic|pybb_is_topic_unread:user %}YES{% else %}NO{% endif %}:'
+                             '{% if topic|pybb_is_topic_unread:anonymous %}YES{% else %}NO{% endif %}:'
+                             '{% if topic|pybb_is_topic_unread:bob %}YES{% else %}NO{% endif %}'))
+        context = Context({'user': self.user,
+                           'anonymous': AnonymousUser(),
+                           'bob': User.objects.create_user('bob', 'bob@localhost', 'bob'),
+                           'topic': self.topic})
+        output = template.render(context)
+        self.assertEqual(output, 'NO:NO:YES')
+
+    
+    def test_pybb_topic_unread(self):
+        self.create_user()
+        self.login_client()
+        bob = User.objects.create_user('bob', 'bob@localhost', 'bob')
+
+        """
+        creates a total of 6 topics in 3 forums.
+            * Forum A
+                * Topic A1
+            * Forum B
+                * Topic B1
+                * Topic B2
+            * Forum C
+                * Topic C1
+                * Topic C2
+                * Topic C3
+        """
+        forums = []
+        topics = []
+        category = Category.objects.create(name='foo')
+        for letter in 'ABC':
+            forum = Forum.objects.create(name=letter, description=letter, category=category)
+            forums.append(forum)
+            topic = Topic.objects.create(name='%s1' % letter, forum=forum, user=bob)
+            self.create_post(topic=topic, user=bob, body='test')
+            topics.append(topic)
+        topic = Topic.objects.create(name='B2', forum=forums[1], user=bob)
+        self.create_post(topic=topic, user=bob, body='test')
+        topics.append(topic)
+        topic = Topic.objects.create(name='C2', forum=forums[2], user=bob)
+        self.create_post(topic=topic, user=bob, body='test')
+        topics.append(topic)
+        topic = Topic.objects.create(name='C3', forum=forums[2], user=bob)
+        self.create_post(topic=topic, user=bob, body='test')
+        topics.append(topic)
+        
+        template = Template(('{% load pybb_tags %}'
+                             '{% for topic in topics|pybb_topic_unread:user %}'
+                             '{{ topic.name }}: {{ topic.unread }}\n'
+                             '{% endfor %}'))
+
+        # test with anonymous: unread should be empty (neither True, neither False)
+        context = Context({'user': AnonymousUser(), 'topics': topics})
+        output = template.render(context)
+        expected = '\n'.join(('A1: ', 'B1: ', 'C1: ',
+                              'B2: ', 'C2: ',
+                              'C3: ', ''))
+        self.assertEqual(output, expected)
+
+        # User should have everything marked as unread
+        context['user'] = self.user
+        output = template.render(context)
+        expected = '\n'.join(('A1: True', 'B1: True', 'C1: True',
+                              'B2: True', 'C2: True',
+                              'C3: True', ''))
+        self.assertEqual(output, expected)
+
+        # mark A1, B1 and C1 as read for user
+        self.client.get(topics[0].get_absolute_url())
+        self.client.get(topics[1].get_absolute_url())
+        self.client.get(topics[2].get_absolute_url())
+        output = template.render(context)
+        expected = '\n'.join(('A1: False', 'B1: False', 'C1: False',
+                              'B2: True', 'C2: True',
+                              'C3: True', ''))
+        self.assertEqual(output, expected)
+
+        # mark all as read for user
+        self.client.get(reverse('pybb:mark_all_as_read'))
+        output = template.render(context)
+        expected = '\n'.join(('A1: False', 'B1: False', 'C1: False',
+                              'B2: False', 'C2: False',
+                              'C3: False', ''))
+        self.assertEqual(output, expected)
+
+
+    def test_pybb_forum_unread(self):
+        self.create_user()
+        self.login_client()
+        bob = User.objects.create_user('bob', 'bob@localhost', 'bob')
+
+        """
+        creates a total of 6 topics in 3 forums.
+            * Forum A
+                * Topic A1
+            * Forum B
+                * Topic B1
+                * Topic B2
+            * Forum C
+                * Topic C1
+                * Topic C2
+                * Topic C3
+        """
+        forums = []
+        topics = []
+        category = Category.objects.create(name='foo')
+        for letter in 'ABC':
+            forum = Forum.objects.create(name=letter, description=letter, category=category)
+            forums.append(forum)
+            topic = Topic.objects.create(name='%s1' % letter, forum=forum, user=bob)
+            self.create_post(topic=topic, user=bob, body='test')
+            topics.append(topic)
+        topic = Topic.objects.create(name='B2', forum=forums[1], user=bob)
+        self.create_post(topic=topic, user=bob, body='test')
+        topics.append(topic)
+        topic = Topic.objects.create(name='C2', forum=forums[2], user=bob)
+        self.create_post(topic=topic, user=bob, body='test')
+        topics.append(topic)
+        topic = Topic.objects.create(name='C3', forum=forums[2], user=bob)
+        self.create_post(topic=topic, user=bob, body='test')
+        topics.append(topic)
+        
+        template = Template(('{% load pybb_tags %}'
+                             '{% for forum in forums|pybb_forum_unread:user %}'
+                             '{{ forum.name }}: {{ forum.unread }}\n'
+                             '{% endfor %}'))
+
+        context = Context({'forums': forums})
+        # test for anonymous user: unread is empty (neither True, neither False)
+        context['user'] = AnonymousUser()
+        output = template.render(context)
+        expected = '\n'.join(('A: ', 'B: ', 'C: ', ''))
+        self.assertEqual(output, expected)
+
+        # User should have everything marked as unread
+        context['user'] = self.user
+        output = template.render(context)
+        expected = '\n'.join(('A: True', 'B: True', 'C: True', ''))
+        self.assertEqual(output, expected)
+
+        # mark A1, B1 and C1 as read for user (so forum A is not unread now)
+        self.client.get(topics[0].get_absolute_url())
+        self.client.get(topics[1].get_absolute_url())
+        self.client.get(topics[2].get_absolute_url())
+        output = template.render(context)
+        expected = '\n'.join(('A: False', 'B: True', 'C: True', ''))
+        self.assertEqual(output, expected)
+
+        # mark all as read for user
+        self.client.get(reverse('pybb:mark_all_as_read'))
+        output = template.render(context)
+        expected = '\n'.join(('A: False', 'B: False', 'C: False', ''))
+        self.assertEqual(output, expected)
+
+    
+    def test_pybb_topic_inline_pagination(self):
+        self.create_user()
+        self.create_initial()
+        self.topic.post_count = defaults.PYBB_TOPIC_PAGE_SIZE * 13
+        nb_pages = int(math.ceil(float(self.topic.post_count) / defaults.PYBB_TOPIC_PAGE_SIZE))
+        
+        template = Template(('{% load pybb_tags %}'
+                             '{% for page in topic|pybb_topic_inline_pagination %}'
+                             '{{ page }} '
+                             '{% endfor %}'))
+        context = Context({'user': AnonymousUser(), 'topic': self.topic})
+        output = template.render(context)
+        expected = '1 2 3 4 ... %d ' % nb_pages
+        self.assertEqual(output, expected)
+
+        self.topic.post_count = defaults.PYBB_TOPIC_PAGE_SIZE * 3
+        output = template.render(context)
+        expected = '1 2 3 '
+        self.assertEqual(output, expected)
+
+    
+    def test_pybb_topic_poll_not_voted(self):
+        self.create_user()
+        self.create_initial()
+        self.topic.poll_type = Topic.POLL_TYPE_SINGLE
+        self.topic.poll_question = 'Where is Brian?'
+        self.topic.save()
+        kitchen = PollAnswer.objects.create(topic=self.topic, text='in the kitchen')
+        bathroom = PollAnswer.objects.create(topic=self.topic, text='in the bathroom')
+        
+        template = Template((
+            '{% load pybb_tags %}'
+            '{% if topic|pybb_topic_poll_not_voted:user %}NOTVOTED{% else %}VOTED{% endif %}:'
+            '{% if topic|pybb_topic_poll_not_voted:anonymous %}NOTVOTED{% else %}VOTED{% endif %}:'
+            '{% if topic|pybb_topic_poll_not_voted:bob %}NOTVOTED{% else %}VOTED{% endif %}'))
+        context = Context({'user': self.user,
+                           'anonymous': AnonymousUser(),
+                           'bob': User.objects.create_user('bob', 'bob@localhost', 'bob'),
+                           'topic': self.topic})
+        self.assertEqual(template.render(context), 'NOTVOTED:NOTVOTED:NOTVOTED')
+
+        # bob answers
+        PollAnswerUser.objects.create(poll_answer=kitchen, user=context['bob'])
+        self.assertEqual(template.render(context), 'NOTVOTED:NOTVOTED:VOTED')
+    
+    def test_endswith(self):
+        template = Template(('{% load pybb_tags %}'
+                             '{{ test|endswith:"the end..." }}:'
+                             '{{ test|endswith:"big bang" }}'))
+        context = Context({'test': 'This is the end...'})
+        self.assertEqual(template.render(context), 'True:False')
+
+    
+    def test_pybb_get_profile(self):
+        template = Template(('{% load pybb_tags %}'
+                             '{% pybb_get_profile bob as user_profile_via_args %}'
+                             '{% pybb_get_profile user=bob as user_profile_via_kwargs %}'
+                             '{% pybb_get_profile anonymous as no_profile %}'
+                             '{{ user_profile_via_args.pk }}:'
+                             '{{ user_profile_via_kwargs.pk }}:'
+                             '{{ no_profile }}'))
+        context = Context({'anonymous': AnonymousUser(),
+                           'bob': User.objects.create_user('bob', 'bob@localhost', 'bob')})
+
+        bob_profile_pk = util.get_pybb_profile(context['bob']).pk
+        self.assertEqual(template.render(context), '%(pk)d:%(pk)d:None' % {'pk': bob_profile_pk})
+
+
+    def test_pybb_get_latest_topics(self):
+        self.create_user()
+        self.create_initial()
+        self.topic.name = '0'
+        self.topic.save()
+        for i in range(1, 10):
+            Topic.objects.create(name='%d' % i,
+                                 user=self.user, forum=self.forum,
+                                 on_moderation = bool(i % 2))
+        
+        context = Context({'anonymous': AnonymousUser(), 'user': self.user})
+        
+        
+        # user can view all it's 5 last topic (default slice is 5)
+        template = Template(('{% load pybb_tags %}'
+                             '{% pybb_get_latest_topics as topics %}'
+                             '{% for topic in topics %}{{ topic.name }},{% endfor %}'))
+        self.assertEqual(template.render(context), '9,8,7,6,5,')
+
+        # user can view all it's topics
+        template = Template(('{% load pybb_tags %}'
+                             '{% pybb_get_latest_topics 20 as topics %}'
+                             '{% for topic in topics %}{{ topic.name }},{% endfor %}'))
+        self.assertEqual(template.render(context), '9,8,7,6,5,4,3,2,1,0,')
+
+        # anonymous can view topics which do not require moderation (the odd ones)
+        template = Template(('{% load pybb_tags %}'
+                             '{% pybb_get_latest_topics 20 anonymous as topics %}'
+                             '{% for topic in topics %}{{ topic.name }},{% endfor %}'))
+        self.assertEqual(template.render(context), '8,6,4,2,0,')
+        
+    
+    def test_pybb_get_latest_posts(self):
+        self.create_user()
+        self.create_initial()
+        self.topic.name = '0'
+        self.topic.save()
+        self.post.body = 'A0'
+        self.post.save()
+        self.create_post(topic=self.topic, body='B0', user=self.user, on_moderation = True)
+        for i in range(1, 10):
+            topic = Topic.objects.create(name='%d' % i, user=self.user, forum=self.forum, )
+            self.create_post(topic=topic, body='A%d' % i, user=self.user)
+            self.create_post(topic=topic, body='B%d' % i, user=self.user, on_moderation = True)
+        
+        context = Context({'anonymous': AnonymousUser(), 'user': self.user})
+
+        ORIG = defaults.PYBB_PREMODERATION
+        # test without PREMODERATION
+        defaults.PYBB_PREMODERATION = False
+        # user can view all it's 5 last post (default slice is 5)
+        template = Template(('{% load pybb_tags %}'
+                             '{% pybb_get_latest_posts as posts %}'
+                             '{% for post in posts %}{{ post.body }},{% endfor %}'))
+        self.assertEqual(template.render(context), 'B9,A9,B8,A8,B7,')
+
+        # user can view all it's posts
+        template = Template(('{% load pybb_tags %}'
+                             '{% pybb_get_latest_posts 20 as posts %}'
+                             '{% for post in posts %}{{ post.body }},{% endfor %}'))
+        self.assertEqual(template.render(context),
+                         'B9,A9,B8,A8,B7,A7,B6,A6,B5,A5,B4,A4,B3,A3,B2,A2,B1,A1,B0,A0,')
+
+        # anonymous can view all posts when PYBB_PREMODERATION is disabled
+        template = Template(('{% load pybb_tags %}'
+                             '{% pybb_get_latest_posts 20 anonymous as posts %}'
+                             '{% for post in posts %}{{ post.body }},{% endfor %}'))
+        self.assertEqual(template.render(context),
+                         'B9,A9,B8,A8,B7,A7,B6,A6,B5,A5,B4,A4,B3,A3,B2,A2,B1,A1,B0,A0,')
+
+        # now, test with PREMODERATION
+        def fake_premoderation(user, body):
+            return True
+        defaults.PYBB_PREMODERATION = fake_premoderation
+        # user can always view all it's posts even if those need moderation
+        template = Template(('{% load pybb_tags %}'
+                             '{% pybb_get_latest_posts 20 as posts %}'
+                             '{% for post in posts %}{{ post.body }},{% endfor %}'))
+        self.assertEqual(template.render(context),
+                         'B9,A9,B8,A8,B7,A7,B6,A6,B5,A5,B4,A4,B3,A3,B2,A2,B1,A1,B0,A0,')
+
+        # anonymous can view posts which do not require moderation (all "A" posts)
+        template = Template(('{% load pybb_tags %}'
+                             '{% pybb_get_latest_posts 20 anonymous as posts %}'
+                             '{% for post in posts %}{{ post.body }},{% endfor %}'))
+        self.assertEqual(template.render(context), 'A9,A8,A7,A6,A5,A4,A3,A2,A1,A0,')
+        defaults.PYBB_PREMODERATION = ORIG
+
+
+    def test_perms_check_app_installed(self):
+        template = Template(('{% load pybb_tags %}'
+                             '{{ "fairy"|check_app_installed }}:{{ "pybb"|check_app_installed }}'))
+        self.assertEqual(template.render(Context()), 'False:True')
+
+    
+    def test_pybbm_calc_topic_views(self):
+        self.create_user()
+        self.create_initial()
+        cache.delete(util.build_cache_key('anonymous_topic_views', topic_id=self.topic.id))
+        context = Context({'topic': self.topic})
+        template = Template(('{% load pybb_tags %}{{ topic|pybbm_calc_topic_views }}'))
+        self.assertEqual(template.render(context), '0')
+
+        self.client.get(self.topic.get_absolute_url())
+        self.assertEqual(template.render(context), '1')
+
+        bob = User.objects.create_user('bob', 'bob@localhost', 'bob')
+        self.get_with_user(self.topic.get_absolute_url(), username='bob', password='bob')
+        context['topic'] = Topic.objects.get(pk=self.topic.pk)
+        self.assertEqual(template.render(context), '2')
+
+        self.client.get(self.topic.get_absolute_url())
+        self.assertEqual(template.render(context), '3')
+
+
+def build_dynamic_test_for_templatetags_perms():
+    """
+    Dynamically creates test method for templatetags which are dynamically created via
+    methods from PermissionHandler (pybb.permissions)
+    """
+    arg_mapping = {
+        'categories': Category.objects.all(),
+        'forums': Forum.objects.all(),
+        'topics': Topic.objects.all(),
+        'posts': Post.objects.all(),
+        'category': Category.objects.first,
+        'forum': Forum.objects.first,
+        'topic': Topic.objects.first,
+        'post': Post.objects.first,
+        'user': User.objects.first,
+    }
+
+    def build_test_method(method_name, method, required_arg, templatetag_name):
+        if method_name.startswith('filter') and len(method_args) == 3:
+            # Method should have 2 args: user and queryset. else we can not test it
+            def test(self):
+                self.create_user()
+                self.create_initial()
+                context = Context({'user': self.user, 'qs': arg_mapping[required_arg]})
+                template = Template(('{%% load pybb_tags %%}'
+                                     '{%% for o in user|%s:qs %%}'
+                                     '{{ o }}'
+                                     '{%% endfor %%}') % templatetag_name)
+                expected = ''.join(['%s' % obj for obj in method(self.user, context['qs'])])
+                self.assertEqual(template.render(context), expected)
+        elif method_name.startswith('may'):
+            def test(self):
+                self.create_user()
+                self.create_initial()
+                context = Context({'user': self.user})
+                if required_arg:
+                    context['obj'] = arg_mapping[required_arg]
+                    if callable(context['obj']):
+                        # because .first() is run when called, we need to call it now, not before
+                        context['obj'] = context['obj']()
+                    expected = '%s' % method(self.user, context['obj'])
+                    tpl = '{%% load pybb_tags %%}{{ user|%s:obj }}' % templatetag_name
+                else:
+                    expected = '%s' % method(self.user)
+                    tpl = '{%% load pybb_tags %%}{{ user|%s }}' % templatetag_name
+                template = Template(tpl)
+                self.assertEqual(template.render(context), expected)
+        else:
+            test = None
+        return test
+
+    for method_name, method in inspect.getmembers(permissions.perms):
+        if not inspect.ismethod(method):
+            continue  # only methods are used to dynamically build templatetags
+        if not method_name.startswith('may') and not method_name.startswith('filter'):
+            continue  # only (may|filter)* methods are used to dynamically build templatetags
+        method_args = inspect.getargspec(method).args
+        args_count = len(method_args)
+        if args_count not in (2, 3):
+            continue  # only methods with 2 or 3 params
+        if method_args[0] != 'self' or method_args[1] != 'user':
+            continue  # only methods with self and user as first args
+
+        templatetag_name = 'pybb_%s' % method_name
+
+        required_arg = None
+        if len(method_args) == 3:
+            # this is a filter which require a queryset or an obj
+            required_arg = method_args[2]
+            if required_arg not in arg_mapping:
+                required_arg = method_name.split('_')[-1]
+            if required_arg not in arg_mapping:
+                # Method or its args are not well named. We can not dynamically test it
+                continue
+        test_method = build_test_method(method_name, method, required_arg, templatetag_name)
+        if test_method:
+            test_method.__name__ = str('test_%s' % templatetag_name)
+            setattr(TestTemplateTags, test_method.__name__, test_method)
+build_dynamic_test_for_templatetags_perms()

--- a/pybb/urls.py
+++ b/pybb/urls.py
@@ -7,7 +7,7 @@ from django.conf.urls import url
 from pybb.defaults import PYBB_NICE_URL
 from pybb.feeds import LastPosts, LastTopics
 from pybb.views import IndexView, CategoryView, ForumView, TopicView, \
-    AddPostView, EditPostView, UserView, PostView, ProfileEditView, \
+    AddPostView, EditPostView, MovePostView, UserView, PostView, ProfileEditView, \
     DeletePostView, StickTopicView, UnstickTopicView, CloseTopicView, \
     OpenTopicView, ModeratePost, TopicPollVoteView, LatestTopicsView, \
     UserTopics, UserPosts, topic_cancel_poll_vote, block_user, unblock_user, \
@@ -65,6 +65,7 @@ urlpatterns += [
     # Post
     url('^post/(?P<pk>\d+)/$', PostView.as_view(), name='post'),
     url('^post/(?P<pk>\d+)/edit/$', EditPostView.as_view(), name='edit_post'),
+    url('^post/(?P<pk>\d+)/move/$', MovePostView.as_view(), name='move_post'),
     url('^post/(?P<pk>\d+)/delete/$', DeletePostView.as_view(),
         name='delete_post'),
     url('^post/(?P<pk>\d+)/moderate/$', ModeratePost.as_view(),

--- a/test/test_project/test_project/settings.py
+++ b/test/test_project/test_project/settings.py
@@ -80,6 +80,8 @@ ROOT_URLCONF = 'test_project.urls'
 SITE_ID = 1
 
 STATIC_URL = '/static/'
+MEDIA_ROOT = os.path.join(BASE_DIR, '..', '..', 'pybb_upload')
+MEDIA_URL = '/media/'
 
 AUTH_USER_MODEL = 'test_app.CustomUser'
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35}-django1{8,9,10}-{sqlite,postgres,mysql} coverage
+envlist = py{27,34,35}-django1{8,9,10}-{sqlite,postgres,mysql},coverage
 
 [testenv:coverage]
 basepython = python2.7


### PR DESCRIPTION
This PR is related to #57 and #219 . It's done with #262 which is required.

It adds a button "move" on each post for moderators. Moving the first post of the topic, move the entire topic. Moving a following post allow moderator to move all following post or just some post into a new topic (which can be in another forum).

#219 is not really done in this PR : we can not move posts into an **existing** topic because :

* selecting the existing topic is painfull. We could add a dependency to select2 (for eg.) to have
  a usable topic input to list existing topics and allow auto complete. Or we could save in session
  selected posts to move, and have a "paste selected posts" button in a topic... Or maybe find
  another solution. In any case, choosen solution will have advantages and disadvantages
  depending your forum and installed apps.
* where do we add the moved posts in the topic ? Do they keep their creation date, breaking the
  existing post flow ? Are they append to the end, changing the past with creation date ?
  The good answer is: "it depends". 

But, if someone really need this feature, it's easy to extends pybbm. The hard thing will be to
decide the behaviour wanted. Extending PostMoveView and PostMoveForm will be the easiest thing:

* extends the MovePostForm:
    * add a field to select the topic
    * overwrite method `get_new_topic` to return the selected topic
* extends the MovePostView to use your own form
* change your url conf to use your view