### PR TITLE
fix TIME_ZONE errors for datetime tests

### DIFF
--- a/test/test_project/test_project/settings.py
+++ b/test/test_project/test_project/settings.py
@@ -86,6 +86,6 @@ MEDIA_URL = '/media/'
 AUTH_USER_MODEL = 'test_app.CustomUser'
 
 LOGIN_URL = '/'
-
+USE_TZ = True
 PYBB_ATTACHMENT_ENABLE = True
 PYBB_PROFILE_RELATED_NAME = 'pybb_customprofile'


### PR DESCRIPTION
related to https://github.com/hovel/pybbm/pull/262#issuecomment-278853942

Now, django is aware of timezone when running tests and whatever the server TZ is, datetime operations are now correct :)

Thanks @lampslave for pointing this.