### PR TITLE
disable post_save handling on fixture load

### DIFF
--- a/pybb/signals.py
+++ b/pybb/signals.py
@@ -14,6 +14,9 @@ def topic_saved(instance, **kwargs):
         notify_forum_subscribers(instance)
 
 def post_saved(instance, **kwargs):
+    # signal triggered by loaddata command, ignore
+    if kwargs.get('raw', False):
+        return
 
     if getattr(instance, '_post_saved_done', False):
         #Do not spam users when post is saved more than once in a same request.
@@ -48,6 +51,10 @@ def post_deleted(instance, **kwargs):
 
 
 def user_saved(instance, created, **kwargs):
+    # signal triggered by loaddata command, ignore
+    if kwargs.get('raw', False):
+        return
+
     if not created:
         return
 


### PR DESCRIPTION
As per [Django docs](https://docs.djangoproject.com/en/2.0/ref/signals/#post-save), applications should not modify the database in `post_save` signal handlers, as the database might not be in a consistent state yet. In practise, doing so in pybb makes it impossible to use dumpdata/loaddata commands.

# Steps to reproduce

1. create django project with pybb, using custom UserProfile as profile model 
2. export data with `manage.py dumpdata`
3. try to load this data again with `manage.py loaddata`

Doing so will cause an `IntegrityError` in step 3, since when the saved User model gets loaded, the signal handler will create a UserProfile instance, and when the UserProfile instance gets loaded later on,  unique constraint will fail.

Solution: don't create or update profile when signal is triggered from fixture load
