### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -16,7 +16,7 @@ There are many ways to contribute to pybbm and you do not need to be a developpe
 2) Improve documentation
 
 * you can correct typos or "bad english"
-* add a new documentation part (for exemple, a "how to" than could help people when using pybb in
+* add a new documentation part (for example, a "how to" than could help people when using pybb in
 some use-case. eg: how to add news fields to `Topic` model).
 
 3) Fix a bug. You should:

--- a/docs/customuser.rst
+++ b/docs/customuser.rst
@@ -6,14 +6,14 @@ is a great feature introduced in django framework since version 1.5. This topic 
 to integrate your custom user model in pybbm forum application.
 
 First of all pybbm uses some fields from standard User model and permission system.
-The simplest way to make your custom model compatible with pybbm is to inherite from
+The simplest way to make your custom model compatible with pybbm is to inherit from
 `django.contrib.auth.models.AbstractUser`
 
-Second way is to meet next requirments:
+Second way is to meet next requirements:
 
 * define USERNAME_FIELD constant, which point to unique field on your model
 * define email, is_staff, is_superuser fields or properties
-* inherite from `django.contib.auth.models.PermissionsMixin` or reproduce django's
+* inherit from `django.contib.auth.models.PermissionsMixin` or reproduce django's
   default permission system
 
 Next step is to decide which model will store all fields for pybb forum profiles.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -20,7 +20,7 @@ Optional dependencies
 
 The following dependencies are optional. You can install them with ``pip install``:
 
-* For better perfomance and easy images thumbnailing you can use any thumbnail django application.
+* For better performance and easy images thumbnailing you can use any thumbnail django application.
   PyBBM by default uses ``sorl.thumbnail`` if it is installed and included in your ``INSTALLED_APPS`` setting.
   It is used for defining the `avatar` field in the `PybbProfile` model and for resizing the avatar
   in the ``pybb/avatar.html`` template. If you decide to install ``sorl.thumbnail`` with django 1.7 you
@@ -91,7 +91,7 @@ Enable your site profile
 
 Setup forum's profile model and ``PYBB_PROFILE_RELATED_NAME`` setting.
 
-If you have no site profile, dafault settings will satisfy your needs.
+If you have no site profile, default settings will satisfy your needs.
 
 If you have a custom user model, which stores all profile fields itself, or if you have custom site profile model, then check that it inherits from ``pybb.profiles.PybbProfile`` or contains all fields and properties from this class.
 

--- a/docs/notifications.rst
+++ b/docs/notifications.rst
@@ -13,7 +13,7 @@ See those settings:
 When notifications are sent
 ---------------------------
 
-Each time a post is saved (created or updated), subcribers will receive an email.
+Each time a post is saved (created or updated), subscribers will receive an email.
 If you configure PYBB to use django-mailer (see :ref:`PYBB_USE_DJANGO_MAILER`), emails
 will be sent when your cron job will run. Else, emails will be sent when post is saved.
 
@@ -30,4 +30,4 @@ You can overwrite three templates:
 My test user is not receiving emails ?!
 ---------------------------------------
 
-Emails matching this rules are not sent: <username>@exemple.com
+Emails matching this rules are not sent: <username>@example.com

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -143,7 +143,7 @@ PYBB_PROFILE_RELATED_NAME
 .........................
 
 Related name from profile's OneToOne relationship to User model. If profile model is User
-model itselt then set it to `None`.
+model itself then set it to `None`.
 
 Default: 'pybb_profile'
 
@@ -192,7 +192,7 @@ Default: 3 (Moscow)
 PYBB_SIGNATURE_MAX_LENGTH
 .........................
 
-Limit of sybmols in user signature
+Limit of symbols in user signature
 
 Default: 1024
 

--- a/docs/templatetags.rst
+++ b/docs/templatetags.rst
@@ -16,7 +16,7 @@ Next filters and tags can be used when `pybb_tags` loaded in template:
       {# operations on queryset there #}
     {% endwith %}
 
-* `pybb_get_latest_topic` and `pybb_get_latest_posts` assigment tags you can use on
+* `pybb_get_latest_topic` and `pybb_get_latest_posts` assignment tags you can use on
   every page for getting latest topics ans posts, for example for rendering in side block.
   Also you can pass `user` parameter (default to user from template context) for geting topics
   or posts available for specific user and `cnt` parameter for get specific count of topics
@@ -25,7 +25,7 @@ Next filters and tags can be used when `pybb_tags` loaded in template:
     {% pybb_get_latest_topic cnt=30 as topics %}
     {# operation on topics list there #}
 
-* `pybb_get_profile` assigment tag can be used to get forum profile instance for any user
+* `pybb_get_profile` assignment tag can be used to get forum profile instance for any user
   passed as `user` argument::
 
     {% pybb_get_profile user=post.user as post_user_profile %}

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -9,7 +9,7 @@ version of python and locally installed python packages.
 Testing with tox (recommended)
 ------------------------------
 
-This is the recommanded way to test pybbm if you want to contribute.
+This is the recommended way to test pybbm if you want to contribute.
 You must have tox installed on your system. (eg: `sudo pip install tox`)
 
 1) Clone your github pybbm fork and go in its directory::
@@ -22,8 +22,8 @@ You must have tox installed on your system. (eg: `sudo pip install tox`)
     tox
 
 That's all ;-). Tox will tests pybbm in multiple environnements configured in the pybbm's tox.ini.
-If you want to test only a specific environnement from that list, you can run tox with the "-e"
-option. For exemple, this command will test pybbm only with python 2.7 and Django 1.8::
+If you want to test only a specific environment from that list, you can run tox with the "-e"
+option. For example, this command will test pybbm only with python 2.7 and Django 1.8::
 
     tox -e py27-django18
 
@@ -39,17 +39,17 @@ Testing in your local environment
 
 If you want to contribute, you should use the "tox way" to test your contributions before
 creating a pull-request ! This testing way will allow you to test pybbm in your current local
-environnement. It is usefull if you have a specific environment which is not covered by tox.ini.
+environment. It is usefull if you have a specific environment which is not covered by tox.ini.
 
-If you already have a working pybb in your environnement, you can go to the step 4.
-Else, steps 1-3 will allow you to have a minimal environnement to run pybb test project.
+If you already have a working pybb in your environment, you can go to the step 4.
+Else, steps 1-3 will allow you to have a minimal environment to run pybb test project.
 
-1) Your environnement must be ready to use pip and install Pillow and lxml python packages.
+1) Your environment must be ready to use pip and install Pillow and lxml python packages.
    For Debian, the simplest way is to install debian python packages with their dependencies::
 
     sudo apt-get install python-pip python-lxml python-pillow
 
-2) Now, your environnement is ready to install python packages via pip. Install pybbm from your
+2) Now, your environment is ready to install python packages via pip. Install pybbm from your
    github fork with the "-e" option to be able to contribute, and install the test requirements::
 
     mkdir -p ~/tests/ && cd ~/tests/

--- a/docs/updates.rst
+++ b/docs/updates.rst
@@ -49,7 +49,7 @@ PyBBM Changelog
 0.16.1 -> 0.17
 --------------
 * Topic and post creation wrapped in transaction
-* All topic/post/poll related forms can be overrided when custom view inherites pybbm view
+* All topic/post/poll related forms can be overridden when custom view inherites pybbm view
 * Demo data for example projects
 * Using active markup engine when quoting posts via javascript
 * Functionality to support disabling default pybbm subscriptions and notifications and
@@ -144,7 +144,7 @@ PyBBM Changelog
   This value can be changed by setting :ref:`PYBB_ANONYMOUS_VIEWS_CACHE_BUFFER`. Also added custom filter
   `pybbm_calc_topic_views` that calc actual views count for topic
 * Fix for migration that may fails on clean mysql installation
-* Fixed perfomance issue with feed views
+* Fixed performance issue with feed views
 * Using custom permissions handler in feed views
 
 0.14.4 -> 0.14.5
@@ -218,7 +218,7 @@ PyBBM Changelog
 0.11 -> 0.12
 ------------
 
-* Fixed bug when the answers to poll unexpectedly deleted. Strongly recommendet to update to this version, if using
+* Fixed bug when the answers to poll unexpectedly deleted. Strongly recommended to update to this version, if using
   polls subsystem
 
 * Polish translation

--- a/pybb/compat.py
+++ b/pybb/compat.py
@@ -27,7 +27,7 @@ else:
 def send_mass_html_mail(emails, *args, **kwargs):
     """
     Sends emails with html alternative if email item has html content.
-    Email item is a tuple with an optionnal html message version :
+    Email item is a tuple with an optional html message version :
         (subject, text_msg, sender, recipient, [html_msg])
     """
     for email in emails:

--- a/pybb/forms.py
+++ b/pybb/forms.py
@@ -278,7 +278,7 @@ class MovePostForm(forms.Form):
             # update posts
             # we can not update with subqueries on same table with mysql 5.5
             # it raises: You can't specify target table 'pybb_post' for update in FROM clause
-            # so we need to get all pks... It's bad for perfs, but posts are not often splited...
+            # so we need to get all pks... It's bad for perfs, but posts are not often splitted...
             posts_pks = [p.pk for p in posts]
             Post.objects.filter(pk__in=posts_pks).update(topic_id=topic.pk)
 
@@ -458,7 +458,7 @@ class ModeratorForm(forms.Form):
 
     def process(self, target_user):
         """
-        Updates the target user moderator privilesges
+        Updates the target user moderator privileges
 
         :param target_user: user to update
         """
@@ -467,7 +467,7 @@ class ModeratorForm(forms.Form):
         initial_forum_set = target_user.forum_set.all()
         # concatenation of the lists into one
         checked_forums = [forum for queryset in cleaned_forums for forum in queryset]
-        # keep all the forums, the request user does't have the permisssion to change
+        # keep all the forums, the request user does't have the permission to change
         untouchable_forums = [forum for forum in initial_forum_set if forum.pk not in self.authorized_forums]
         if django.VERSION < (1, 9):
             target_user.forum_set = checked_forums + untouchable_forums

--- a/pybb/models.py
+++ b/pybb/models.py
@@ -416,7 +416,7 @@ class TopicReadTrackerManager(models.Manager):
         """
         Correctly create tracker in mysql db on default REPEATABLE READ transaction mode
 
-        It's known problem when standrard get_or_create method return can raise exception
+        It's known problem when standard get_or_create method return can raise exception
         with correct data in mysql database.
         See http://stackoverflow.com/questions/2235318/how-do-i-deal-with-this-race-condition-in-django/2235624
         """
@@ -454,7 +454,7 @@ class ForumReadTrackerManager(models.Manager):
         """
         Correctly create tracker in mysql db on default REPEATABLE READ transaction mode
 
-        It's known problem when standrard get_or_create method return can raise exception
+        It's known problem when standard get_or_create method return can raise exception
         with correct data in mysql database.
         See http://stackoverflow.com/questions/2235318/how-do-i-deal-with-this-race-condition-in-django/2235624
         """

--- a/pybb/tests.py
+++ b/pybb/tests.py
@@ -1231,7 +1231,7 @@ class FeaturesTest(TestCase, SharedTestModule):
         values['topics'] = 'all'
         response = client.post(url, values, follow=True)
         self.assertEqual(response.status_code, 200)
-        # user2 shoud now be subscribed to all self.forum's topics
+        # user2 should now be subscribed to all self.forum's topics
         subscribed_topics = list(user2.subscriptions.all().order_by('name').values_list('name', flat=True))
         expected_topics = list(self.forum.topics.all().order_by('name').values_list('name', flat=True))
         self.assertEqual(subscribed_topics, expected_topics)
@@ -1246,7 +1246,7 @@ class FeaturesTest(TestCase, SharedTestModule):
         values['topics'] = 'all'
         response = client.post(url, values, follow=True)
         self.assertEqual(response.status_code, 200)
-        # user2 shoud now be subscribed to zero topic
+        # user2 should now be subscribed to zero topic
         topics = list(user2.subscriptions.all().values_list('name', flat=True))
         self.assertEqual(topics, [])
 
@@ -1589,7 +1589,7 @@ class MoveAndSplitPostTest(TestCase, SharedTestModule):
 
         form_values = self.get_form_values(response, 'move-post-form')
 
-        # post stay in same forum but are splited in a new topic
+        # post stay in same forum but are splitted in a new topic
         form_values['move_to'] = self.forum_1.pk
         form_values['number'] = 2
         response = self.client.post(split_posts_url, form_values, follow=True)
@@ -1597,7 +1597,7 @@ class MoveAndSplitPostTest(TestCase, SharedTestModule):
         forum_2 = Forum.objects.get(pk=self.forum_2.pk)
         topic_1 = Topic.objects.get(pk=self.topic.pk)
         topic_2 = Post.objects.get(pk=self.posts[1].pk).topic
-        # splited in 2 topics
+        # splitted in 2 topics
         self.assertNotEqual(topic_1.pk, topic_2.pk)
         self.assertEqual(topic_1.name, topic_2.name)
         self.assertNotEqual(topic_1.slug, topic_2.slug)  # can't keep same slug in same forum
@@ -1622,7 +1622,7 @@ class MoveAndSplitPostTest(TestCase, SharedTestModule):
 
         form_values = self.get_form_values(response, 'move-post-form')
 
-        # posts splited in forum 2
+        # posts splitted in forum 2
         form_values['move_to'] = self.forum_2.pk
         form_values['number'] = 2
         response = self.client.post(split_posts_url, form_values, follow=True)
@@ -1630,7 +1630,7 @@ class MoveAndSplitPostTest(TestCase, SharedTestModule):
         forum_2 = Forum.objects.get(pk=self.forum_2.pk)
         topic_1 = Topic.objects.get(pk=self.topic.pk)
         topic_2 = Post.objects.get(pk=self.posts[1].pk).topic
-        # splited in 2 topics
+        # splitted in 2 topics
         self.assertNotEqual(topic_1.pk, topic_2.pk)
         self.assertEqual(topic_1.posts.count(), 3)
         self.assertEqual(topic_2.posts.count(), 3)
@@ -2132,14 +2132,14 @@ class MarkupParserTest(TestCase, SharedTestModule):
         self.ORIG_PYBB_QUOTE_ENGINES = util.PYBB_QUOTE_ENGINES
         util.PYBB_MARKUP_ENGINES = {
             'bbcode': 'pybb.markup.bbcode.BBCodeParser',  # default parser
-            'bbcode_custom': 'test_project.markup_parsers.CustomBBCodeParser',  # overrided default parser
+            'bbcode_custom': 'test_project.markup_parsers.CustomBBCodeParser',  # overridden default parser
             'liberator': 'test_project.markup_parsers.LiberatorParser',  # completely new parser
             'fake': 'pybb.markup.base.BaseParser',  # base parser
             'markdown': defaults.markdown  # old-style callable parser,
         }
         util.PYBB_QUOTE_ENGINES = {
             'bbcode': 'pybb.markup.bbcode.BBCodeParser',  # default parser
-            'bbcode_custom': 'test_project.markup_parsers.CustomBBCodeParser',  # overrided default parser
+            'bbcode_custom': 'test_project.markup_parsers.CustomBBCodeParser',  # overridden default parser
             'liberator': 'test_project.markup_parsers.LiberatorParser',  # completely new parser
             'fake': 'pybb.markup.base.BaseParser',  # base parser
             'markdown': lambda text, username="": '>' + text.replace('\n', '\n>').replace('\r', '\n>') + '\n'  # old-style callable parser


### PR DESCRIPTION
There are small typos in:
- docs/contributing.rst
- docs/customuser.rst
- docs/install.rst
- docs/notifications.rst
- docs/settings.rst
- docs/templatetags.rst
- docs/testing.rst
- docs/updates.rst
- pybb/compat.py
- pybb/forms.py
- pybb/models.py
- pybb/tests.py

Fixes:
- Should read `splitted` rather than `splited`.
- Should read `environment` rather than `environnement`.
- Should read `overridden` rather than `overrided`.
- Should read `example` rather than `exemple`.
- Should read `standard` rather than `standrard`.
- Should read `should` rather than `shoud`.
- Should read `performance` rather than `perfomance`.
- Should read `inherit` rather than `inherite`.
- Should read `assignment` rather than `assigment`.
- Should read `symbols` rather than `sybmols`.
- Should read `subscribers` rather than `subcribers`.
- Should read `requirements` rather than `requirments`.
- Should read `recommended` rather than `recommendet`.
- Should read `recommended` rather than `recommanded`.
- Should read `privileges` rather than `privilesges`.
- Should read `permission` rather than `permisssion`.
- Should read `optional` rather than `optionnal`.
- Should read `itself` rather than `itselt`.
- Should read `default` rather than `dafault`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md