### PR TITLE
Django 4.0 compatibility patches

### DIFF
--- a/pybb/admin.py
+++ b/pybb/admin.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8
 from copy import deepcopy
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib import admin
 from django.urls import reverse
 

--- a/pybb/apps.py
+++ b/pybb/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class PybbConfig(AppConfig):

--- a/pybb/compat.py
+++ b/pybb/compat.py
@@ -1,6 +1,6 @@
 import django
 from django.conf import settings
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.text import slugify as django_slugify
 from unidecode import unidecode
 from pybb import defaults
@@ -112,4 +112,4 @@ def slugify(text):
     :param text: any unicode text
     :return: slugified version of passed text
     """
-    return django_slugify(force_text(unidecode(text)))
+    return django_slugify(force_str(unidecode(text)))

--- a/pybb/feeds.py
+++ b/pybb/feeds.py
@@ -2,7 +2,7 @@
 from django.contrib.syndication.views import Feed
 from django.urls import reverse
 from django.utils.feedgenerator import Atom1Feed
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from pybb.models import Post, Topic
 

--- a/pybb/forms.py
+++ b/pybb/forms.py
@@ -8,9 +8,9 @@ from django.core.exceptions import FieldError, PermissionDenied
 from django.forms.models import inlineformset_factory, BaseInlineFormSet
 from django.utils.decorators import method_decorator
 from django.utils.text import Truncator
-from django.utils.translation import ugettext, ugettext_lazy
+from django.utils.translation import gettext, gettext_lazy
 from django.utils.timezone import now as tznow
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from pybb import compat, defaults, util, permissions
 from pybb.models import Topic, Post, Attachment, PollAnswer, \
@@ -28,7 +28,7 @@ class AttachmentForm(forms.ModelForm):
 
     def clean_file(self):
         if self.cleaned_data['file'].size > defaults.PYBB_ATTACHMENT_SIZE_LIMIT:
-            raise forms.ValidationError(ugettext('Attachment is too big'))
+            raise forms.ValidationError(gettext('Attachment is too big'))
         return self.cleaned_data['file']
 
 AttachmentFormSet = inlineformset_factory(Post, Attachment, extra=1, form=AttachmentForm)
@@ -46,9 +46,9 @@ class BasePollAnswerFormset(BaseInlineFormSet):
                      len(self.deleted_forms))
         if forms_cnt > defaults.PYBB_POLL_MAX_ANSWERS:
             raise forms.ValidationError(
-                ugettext('You can''t add more than %s answers for poll' % defaults.PYBB_POLL_MAX_ANSWERS))
+                gettext('You can''t add more than %s answers for poll' % defaults.PYBB_POLL_MAX_ANSWERS))
         if forms_cnt < 2:
-            raise forms.ValidationError(ugettext('Add two or more answers for this poll'))
+            raise forms.ValidationError(gettext('Add two or more answers for this poll'))
 
 
 PollAnswerFormSet = inlineformset_factory(Topic, PollAnswer, extra=2, max_num=defaults.PYBB_POLL_MAX_ANSWERS,
@@ -56,13 +56,13 @@ PollAnswerFormSet = inlineformset_factory(Topic, PollAnswer, extra=2, max_num=de
 
 
 class PostForm(forms.ModelForm):
-    name = forms.CharField(label=ugettext_lazy('Subject'))
-    poll_type = forms.TypedChoiceField(label=ugettext_lazy('Poll type'), choices=Topic.POLL_TYPE_CHOICES, coerce=int)
+    name = forms.CharField(label=gettext_lazy('Subject'))
+    poll_type = forms.TypedChoiceField(label=gettext_lazy('Poll type'), choices=Topic.POLL_TYPE_CHOICES, coerce=int)
     poll_question = forms.CharField(
-        label=ugettext_lazy('Poll question'),
+        label=gettext_lazy('Poll question'),
         required=False,
         widget=forms.Textarea(attrs={'class': 'no-markitup'}))
-    slug = forms.CharField(label=ugettext_lazy('Topic slug'), required=False)
+    slug = forms.CharField(label=gettext_lazy('Topic slug'), required=False)
 
     class Meta(object):
         model = Post
@@ -121,7 +121,7 @@ class PostForm(forms.ModelForm):
         poll_type = self.cleaned_data.get('poll_type', None)
         poll_question = self.cleaned_data.get('poll_question', None)
         if poll_type is not None and poll_type != Topic.POLL_TYPE_NONE and not poll_question:
-            raise forms.ValidationError(ugettext('Poll''s question is required when adding a poll'))
+            raise forms.ValidationError(gettext('Poll''s question is required when adding a poll'))
 
         return self.cleaned_data
 
@@ -205,7 +205,7 @@ class MovePostForm(forms.Form):
             choices.insert(0, (0, _('None')))
             choices.insert(0, (-1, _('All')))
             self.fields['number'] = forms.TypedChoiceField(
-                label=ugettext_lazy('Number of following posts to move with'),
+                label=gettext_lazy('Number of following posts to move with'),
                 choices=choices, required=True, coerce=int,
             )
             # we move the entire topic, so we want to change it's forum.
@@ -231,7 +231,7 @@ class MovePostForm(forms.Form):
                 name = '%s' % forum
             choices[-1][1].append((forum.pk, name))
 
-        self.fields['move_to'] = forms.ChoiceField(label=ugettext_lazy('Move to forum'),
+        self.fields['move_to'] = forms.ChoiceField(label=gettext_lazy('Move to forum'),
                                                    initial=self.forum.pk,
                                                    choices=choices, required=True,)
         self.fields['name'] = forms.CharField(label=_('New subject'),
@@ -296,7 +296,7 @@ class AdminPostForm(PostForm):
     Superusers can post messages from any user and from any time
     If no user with specified name - new user will be created
     """
-    login = forms.CharField(label=ugettext_lazy('User'))
+    login = forms.CharField(label=gettext_lazy('User'))
 
     def __init__(self, *args, **kwargs):
         if args:
@@ -332,7 +332,7 @@ try:
 
         def clean_avatar(self):
             if self.cleaned_data['avatar'] and (self.cleaned_data['avatar'].size > defaults.PYBB_MAX_AVATAR_SIZE):
-                forms.ValidationError(ugettext('Avatar is too large, max size: %s bytes' %
+                forms.ValidationError(gettext('Avatar is too large, max size: %s bytes' %
                                                defaults.PYBB_MAX_AVATAR_SIZE))
             return self.cleaned_data['avatar']
 

--- a/pybb/models.py
+++ b/pybb/models.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 from django.db import models, transaction, DatabaseError
 from django.utils.functional import cached_property
 from django.utils.html import strip_tags
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.utils.timezone import now as tznow
 
 from pybb.compat import get_user_model_path, get_username_field, get_atomic_func, slugify

--- a/pybb/profiles.py
+++ b/pybb/profiles.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.db import models
 from django.utils.encoding import force_text
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.utils.translation.trans_real import get_supported_language_variant
 
 from pybb import defaults, util

--- a/pybb/profiles.py
+++ b/pybb/profiles.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation.trans_real import get_supported_language_variant
 
@@ -62,4 +62,4 @@ class PybbProfile(models.Model):
             if not defaults.PYBB_PROFILE_RELATED_NAME:  # we now in user custom model itself
                 return self.get_username()
         except Exception:
-            return force_text(self)
+            return force_str(self)

--- a/pybb/templatetags/pybb_tags.py
+++ b/pybb/templatetags/pybb_tags.py
@@ -8,7 +8,7 @@ import django
 from django import template
 from django.core.cache import cache
 from django.utils.safestring import mark_safe
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 from django.utils.html import escape
 from django.utils.translation import gettext as _, ungettext
 from django.utils import dateformat
@@ -88,7 +88,7 @@ def pybb_link(object, anchor=''):
 
     url = hasattr(object, 'get_absolute_url') and object.get_absolute_url() or None
     #noinspection PyRedeclaration
-    anchor = anchor or smart_text(object)
+    anchor = anchor or smart_str(object)
     return mark_safe('<a href="%s">%s</a>' % (url, escape(anchor)))
 
 

--- a/pybb/templatetags/pybb_tags.py
+++ b/pybb/templatetags/pybb_tags.py
@@ -10,7 +10,7 @@ from django.core.cache import cache
 from django.utils.safestring import mark_safe
 from django.utils.encoding import smart_text
 from django.utils.html import escape
-from django.utils.translation import ugettext as _, ungettext
+from django.utils.translation import gettext as _, ungettext
 from django.utils import dateformat
 from django.utils.timezone import timedelta
 from django.utils.timezone import now as tznow

--- a/pybb/templatetags/pybb_tags.py
+++ b/pybb/templatetags/pybb_tags.py
@@ -10,7 +10,7 @@ from django.core.cache import cache
 from django.utils.safestring import mark_safe
 from django.utils.encoding import smart_str
 from django.utils.html import escape
-from django.utils.translation import gettext as _, ungettext
+from django.utils.translation import gettext as _, ngettext
 from django.utils import dateformat
 from django.utils.timezone import timedelta
 from django.utils.timezone import now as tznow
@@ -59,11 +59,11 @@ def pybb_user_time(context_time, user):
 
     if delta.days == 0:
         if delta.seconds < 60:
-            msg = ungettext('%d second ago', '%d seconds ago', delta.seconds)
+            msg = ngettext('%d second ago', '%d seconds ago', delta.seconds)
             return msg % delta.seconds
         elif delta.seconds < 3600:
             minutes = int(delta.seconds / 60)
-            msg = ungettext('%d minute ago', '%d minutes ago', minutes)
+            msg = ngettext('%d minute ago', '%d minutes ago', minutes)
             return msg % minutes
     if user.is_authenticated:
         if time.daylight: # pragma: no cover

--- a/pybb/urls.py
+++ b/pybb/urls.py
@@ -1,6 +1,6 @@
 
 
-from django.conf.urls import url
+from django.urls import re_path
 
 from pybb.defaults import PYBB_NICE_URL
 from pybb.feeds import LastPosts, LastTopics
@@ -16,87 +16,87 @@ app_name = 'pybbm'
 
 urlpatterns = [
     # Syndication feeds
-    url('^feeds/posts/$', LastPosts(), name='feed_posts'),
-    url('^feeds/topics/$', LastTopics(), name='feed_topics'),
+    re_path('^feeds/posts/$', LastPosts(), name='feed_posts'),
+    re_path('^feeds/topics/$', LastTopics(), name='feed_topics'),
 ]
 
 urlpatterns += [
     # Index, Category, Forum
-    url('^$', IndexView.as_view(), name='index'),
-    url('^category/(?P<pk>\d+)/$', CategoryView.as_view(), name='category'),
-    url('^forum/(?P<pk>\d+)/$', ForumView.as_view(), name='forum'),
+    re_path('^$', IndexView.as_view(), name='index'),
+    re_path('^category/(?P<pk>\d+)/$', CategoryView.as_view(), name='category'),
+    re_path('^forum/(?P<pk>\d+)/$', ForumView.as_view(), name='forum'),
 
     # User
-    url('^users/(?P<username>[^/]+)/$', UserView.as_view(), name='user'),
-    url('^block_user/([^/]+)/$', block_user, name='block_user'),
-    url('^unblock_user/([^/]+)/$', unblock_user, name='unblock_user'),
-    url(r'^users/(?P<username>[^/]+)/topics/$', UserTopics.as_view(),
+    re_path('^users/(?P<username>[^/]+)/$', UserView.as_view(), name='user'),
+    re_path('^block_user/([^/]+)/$', block_user, name='block_user'),
+    re_path('^unblock_user/([^/]+)/$', unblock_user, name='unblock_user'),
+    re_path(r'^users/(?P<username>[^/]+)/topics/$', UserTopics.as_view(),
         name='user_topics'),
-    url(r'^users/(?P<username>[^/]+)/posts/$', UserPosts.as_view(),
+    re_path(r'^users/(?P<username>[^/]+)/posts/$', UserPosts.as_view(),
         name='user_posts'),
-    url(r'^users/(?P<username>[^/]+)/edit-privileges/$',
+    re_path(r'^users/(?P<username>[^/]+)/edit-privileges/$',
         UserEditPrivilegesView.as_view(), name='edit_privileges'),
 
     # Profile
-    url('^profile/edit/$', ProfileEditView.as_view(), name='edit_profile'),
+    re_path('^profile/edit/$', ProfileEditView.as_view(), name='edit_profile'),
 
     # Topic
-    url('^topic/(?P<pk>\d+)/$', TopicView.as_view(), name='topic'),
-    url('^topic/(?P<pk>\d+)/stick/$', StickTopicView.as_view(),
+    re_path('^topic/(?P<pk>\d+)/$', TopicView.as_view(), name='topic'),
+    re_path('^topic/(?P<pk>\d+)/stick/$', StickTopicView.as_view(),
         name='stick_topic'),
-    url('^topic/(?P<pk>\d+)/unstick/$', UnstickTopicView.as_view(),
+    re_path('^topic/(?P<pk>\d+)/unstick/$', UnstickTopicView.as_view(),
         name='unstick_topic'),
-    url('^topic/(?P<pk>\d+)/close/$', CloseTopicView.as_view(),
+    re_path('^topic/(?P<pk>\d+)/close/$', CloseTopicView.as_view(),
         name='close_topic'),
-    url('^topic/(?P<pk>\d+)/open/$', OpenTopicView.as_view(),
+    re_path('^topic/(?P<pk>\d+)/open/$', OpenTopicView.as_view(),
         name='open_topic'),
-    url('^topic/(?P<pk>\d+)/poll_vote/$', TopicPollVoteView.as_view(),
+    re_path('^topic/(?P<pk>\d+)/poll_vote/$', TopicPollVoteView.as_view(),
         name='topic_poll_vote'),
-    url('^topic/(?P<pk>\d+)/cancel_poll_vote/$', topic_cancel_poll_vote,
+    re_path('^topic/(?P<pk>\d+)/cancel_poll_vote/$', topic_cancel_poll_vote,
         name='topic_cancel_poll_vote'),
-    url('^topic/latest/$', LatestTopicsView.as_view(), name='topic_latest'),
+    re_path('^topic/latest/$', LatestTopicsView.as_view(), name='topic_latest'),
 
     # Add topic/post
-    url('^forum/(?P<forum_id>\d+)/topic/add/$', AddPostView.as_view(),
+    re_path('^forum/(?P<forum_id>\d+)/topic/add/$', AddPostView.as_view(),
         name='add_topic'),
-    url('^topic/(?P<topic_id>\d+)/post/add/$', AddPostView.as_view(),
+    re_path('^topic/(?P<topic_id>\d+)/post/add/$', AddPostView.as_view(),
         name='add_post'),
 
     # Post
-    url('^post/(?P<pk>\d+)/$', PostView.as_view(), name='post'),
-    url('^post/(?P<pk>\d+)/edit/$', EditPostView.as_view(), name='edit_post'),
-    url('^post/(?P<pk>\d+)/move/$', MovePostView.as_view(), name='move_post'),
-    url('^post/(?P<pk>\d+)/delete/$', DeletePostView.as_view(),
+    re_path('^post/(?P<pk>\d+)/$', PostView.as_view(), name='post'),
+    re_path('^post/(?P<pk>\d+)/edit/$', EditPostView.as_view(), name='edit_post'),
+    re_path('^post/(?P<pk>\d+)/move/$', MovePostView.as_view(), name='move_post'),
+    re_path('^post/(?P<pk>\d+)/delete/$', DeletePostView.as_view(),
         name='delete_post'),
-    url('^post/(?P<pk>\d+)/moderate/$', ModeratePost.as_view(),
+    re_path('^post/(?P<pk>\d+)/moderate/$', ModeratePost.as_view(),
         name='moderate_post'),
 
     # Attachment
     # url('^attachment/(\w+)/$', 'show_attachment', name='pybb_attachment'),
 
     # Subscription
-    url('^subscription/topic/(\d+)/delete/$',
+    re_path('^subscription/topic/(\d+)/delete/$',
         delete_subscription, name='delete_subscription'),
-    url('^subscription/topic/(\d+)/add/$',
+    re_path('^subscription/topic/(\d+)/add/$',
         add_subscription, name='add_subscription'),
-    url('^subscription/forum/(?P<pk>\d+)/$',
+    re_path('^subscription/forum/(?P<pk>\d+)/$',
         ForumSubscriptionView.as_view(), name='forum_subscription'),
 
     # API
-    url('^api/post_ajax_preview/$', post_ajax_preview,
+    re_path('^api/post_ajax_preview/$', post_ajax_preview,
         name='post_ajax_preview'),
 
     # Commands
-    url('^mark_all_as_read/$', mark_all_as_read, name='mark_all_as_read')
+    re_path('^mark_all_as_read/$', mark_all_as_read, name='mark_all_as_read')
 ]
 
 if PYBB_NICE_URL:
     urlpatterns += [
-        url(r'^c/(?P<slug>[\w-]+)/$', CategoryView.as_view(), name='category'),
-        url(r'^c/(?P<category_slug>[\w-]+)/(?P<slug>[\w-]+)/$',
+        re_path(r'^c/(?P<slug>[\w-]+)/$', CategoryView.as_view(), name='category'),
+        re_path(r'^c/(?P<category_slug>[\w-]+)/(?P<slug>[\w-]+)/$',
             ForumView.as_view(),
             name='forum'),
-        url(
+        re_path(
             r'^c/(?P<category_slug>[\w-]+)/(?P<forum_slug>[\w-]+)/(?P<slug>[\w-]+)/$',
             TopicView.as_view(), name='topic'),
     ]

--- a/pybb/util.py
+++ b/pybb/util.py
@@ -4,7 +4,7 @@ import warnings
 import uuid
 
 from importlib import import_module
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from pybb import compat
 
 from pybb.compat import get_username_field, get_user_model

--- a/pybb/views.py
+++ b/pybb/views.py
@@ -11,7 +11,7 @@ from django.forms.utils import ErrorList
 from django.http import HttpResponseRedirect, HttpResponse, Http404, HttpResponseBadRequest,\
     HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.utils.decorators import method_decorator
 from django.views.decorators.http import require_POST
 from django.views.generic.edit import ModelFormMixin

--- a/test/example_bootstrap/example_bootstrap/urls.py
+++ b/test/example_bootstrap/example_bootstrap/urls.py
@@ -1,10 +1,10 @@
 
 import django
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from django.contrib import admin
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls) if django.VERSION < (1, 10) else admin.site.urls),
-    url(r'^accounts/', include('registration.urls')),
-    url(r'^', include('pybb.urls', namespace='pybb')),
+    re_path(r'^admin/', include(admin.site.urls) if django.VERSION < (1, 10) else admin.site.urls),
+    re_path(r'^accounts/', include('registration.urls')),
+    re_path(r'^', include('pybb.urls', namespace='pybb')),
 ]

--- a/test/example_thirdparty/example_thirdparty/urls.py
+++ b/test/example_thirdparty/example_thirdparty/urls.py
@@ -1,22 +1,22 @@
 
 import django
 from account.views import ChangePasswordView, SignupView, LoginView
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from django.contrib import admin
 from example_thirdparty.forms import SignupFormWithCaptcha
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls) if django.VERSION < (1, 10) else admin.site.urls),
+    re_path(r'^admin/', include(admin.site.urls) if django.VERSION < (1, 10) else admin.site.urls),
 
     # aliases to match original django-registration urls
-    url(r"^accounts/password/$", ChangePasswordView.as_view(),
+    re_path(r"^accounts/password/$", ChangePasswordView.as_view(),
         name="auth_password_change"),
-    url(r"^accounts/signup/$",
+    re_path(r"^accounts/signup/$",
         SignupView.as_view(form_class=SignupFormWithCaptcha),
         name="registration_register"),
-    url(r"^accounts/login/$", LoginView.as_view(), name="auth_login"),
+    re_path(r"^accounts/login/$", LoginView.as_view(), name="auth_login"),
 
-    url(r'^accounts/', include('account.urls')),
-    url(r'^captcha/', include('captcha.urls')),
-    url(r'^', include('pybb.urls', namespace='pybb')),
+    re_path(r'^accounts/', include('account.urls')),
+    re_path(r'^captcha/', include('captcha.urls')),
+    re_path(r'^', include('pybb.urls', namespace='pybb')),
 ]

--- a/test/test_project/test_app/apps.py
+++ b/test/test_project/test_app/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class TestApp(AppConfig):

--- a/test/test_project/test_project/urls.py
+++ b/test/test_project/test_project/urls.py
@@ -1,9 +1,9 @@
 
 import django
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from django.contrib import admin
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls) if django.VERSION < (1, 10) else admin.site.urls),
-    url(r'^', include('pybb.urls', namespace='pybb')),
+    re_path(r'^admin/', include(admin.site.urls) if django.VERSION < (1, 10) else admin.site.urls),
+    re_path(r'^', include('pybb.urls', namespace='pybb')),
 ]


### PR DESCRIPTION
`ugettext`, `ugettext_lazy`, `force_str`, `smart_str` and `url` were removed in Django 4.0. This patch replaces them with their up-to-date counterparts, allowing to run PyBBM with Django 4.0+